### PR TITLE
correct mimie types for attached files

### DIFF
--- a/code/UserDefinedForm.php
+++ b/code/UserDefinedForm.php
@@ -714,7 +714,7 @@ JS
 			if($attachments){
 				foreach($attachments as $file){
 					if($file->ID != 0) {
-						$email->attachFile($file->Filename,$file->Filename, $file->getFileType());
+						$email->attachFile($file->Filename,$file->Filename, HTTP::getMimeType($file->Filename));
 					}
 				}
 			}


### PR DESCRIPTION
...esweeper not liking the "Content-Type" and they see the following warning:

Bad Data
Recognize SMTP messages
The Content-Type header is invalid - Word document; name="SOMEDOCUEMNT.doc"
