### PR TITLE
BUGFIX: prevent form from expiring on users - ping regularly.

### DIFF
--- a/code/model/UserDefinedForm.php
+++ b/code/model/UserDefinedForm.php
@@ -298,6 +298,7 @@ class UserDefinedForm_Controller extends Page_Controller {
 		// load the jquery
 		Requirements::javascript(FRAMEWORK_DIR .'/thirdparty/jquery/jquery.js');
 		Requirements::javascript('userforms/thirdparty/jquery-validate/jquery.validate.min.js');
+		Requirements::javascript('userforms/javascript/UserForm_frontend.js');
 	}
 	
 	/**
@@ -323,6 +324,13 @@ class UserDefinedForm_Controller extends Page_Controller {
 			'Content' => DBField::create_field('HTMLText', $this->Content),
 			'Form' => $this->Form()
 		);
+	}
+
+	/**
+	 * Keep the session alive for the user.
+	 */
+	function ping() {
+		return 1;
 	}
 
 	/**

--- a/javascript/UserForm_frontend.js
+++ b/javascript/UserForm_frontend.js
@@ -1,0 +1,9 @@
+jQuery(function($) {
+	/**
+	 * Make sure the form does not expire on the user.
+	 */
+	setInterval(function() {
+		// Ping every 3 mins.
+		$.ajax({url: "UserDefinedForm_Controller/ping"});
+	}, 180*1000);
+});


### PR DESCRIPTION
The form throws a CSRF error if left for too long by itself. This is
especially important for long forms.

Use local ping function, as the CMS ping returns 403 when BasicAuth is
enabled.
