### PR TITLE
Fixing small issue with non-admin user rights and EmailRecipient

### DIFF
--- a/code/model/UserDefinedForm.php
+++ b/code/model/UserDefinedForm.php
@@ -975,6 +975,10 @@ class UserDefinedForm_EmailRecipient extends DataObject {
 		return $fields;
 	}
 	
+	public function canView($member = null) {
+		return $this->Form()->canView();
+	}
+	
 	public function canEdit($member = null) {
 		return $this->Form()->canEdit();
 	}


### PR DESCRIPTION
Non-admin Users in SilverStripe 3.0 can't see the EmailRecipient DataObjects due to lacking permissions. "Inheriting" the "view" permissions from the Form (eg. doing the same as with "edit" and "delete" permissions) fixes this issue.
