### PR TITLE
fixed the 'always modified' in sitetree

### DIFF
--- a/code/model/UserDefinedForm.php
+++ b/code/model/UserDefinedForm.php
@@ -280,7 +280,24 @@ class UserDefinedForm extends Page {
 	 * 		for now just say its always modified
 	 */
 	public function getIsModifiedOnStage() {
-		return true;
+		// new unsaved pages could be never be published
+		if($this->isNew()) return false;
+		
+		$stageVersion = Versioned::get_versionnumber_by_stage('UserDefinedForm', 'Stage', $this->ID);
+		$liveVersion =	Versioned::get_versionnumber_by_stage('UserDefinedForm', 'Live', $this->ID);
+
+		$isModified = ($stageVersion && $stageVersion != $liveVersion);
+		if (!$isModified) {
+			if($this->Fields()) {
+				foreach($this->Fields() as $field) {
+					if ($field->getIsModifiedOnStage()) {
+					     $isModified = true;
+					     break;
+					}
+				}
+			}		
+		}
+		return $isModified;
 	}
 }
 

--- a/code/model/formfields/EditableFormField.php
+++ b/code/model/formfields/EditableFormField.php
@@ -107,6 +107,31 @@ class EditableFormField extends DataObject {
 		$this->deleteFromStage($stage);
 	}
 	
+	/**
+	 * checks wether record is new, copied from Sitetree 
+	 */
+	function isNew() {
+		if(empty($this->ID)) return true;
+
+		if(is_numeric($this->ID)) return false;
+
+		return stripos($this->ID, 'new') === 0;
+	}
+	
+	/**
+	 * checks if records is changed on stage
+	 * @return boolean 
+	 */
+	public function getIsModifiedOnStage() {
+		// new unsaved fields could be never be published
+		if($this->isNew()) return false;
+		
+		$stageVersion = Versioned::get_versionnumber_by_stage('EditableFormField', 'Stage', $this->ID);
+		$liveVersion =	Versioned::get_versionnumber_by_stage('EditableFormField', 'Live', $this->ID);
+
+		return ($stageVersion && $stageVersion != $liveVersion);
+	}
+	
 	
 	/**
 	 * Show this form on load or not


### PR DESCRIPTION
userforms were always 'modified' in the sitetree. Fixed the issue by
checking the userdefinedform record and the formfields.
