### PR TITLE
Fix malformed ajax url for adding options when used in combination with translatable

### DIFF
--- a/javascript/UserForm.js
+++ b/javascript/UserForm.js
@@ -84,6 +84,12 @@
 			});
 		};
 		
+		userforms.appendToURL = function(url, pathsegmenttobeadded) {
+			var parts = url.match(/([^\?#]*)?(\?[^#]*)?(#.*)?/);
+			for(var i in parts) if(!parts[i]) parts[i] = '';
+			return parts[1] + pathsegmenttobeadded + parts[2] + parts[3];
+		}
+
 		/**
 		 * Workaround for not refreshing the sort.
 		 * 
@@ -256,7 +262,7 @@
 
 					// variables
 					var options = $(this).parent("li");
-					var action = $("#Form_EditForm").attr("action") + '/field/Fields/addoptionfield';
+					var action = userforms.appendToURL($("#Form_EditForm").attr("action"), '/field/Fields/addoptionfield');
 					var parent = $(this).attr("rel");
 
 					// send ajax request to the page


### PR DESCRIPTION
When using userforms in combination with translatable you cannot add options to dropdown, checkboxgroup, radio group, etc fields because of a malformed ajax url.

In UserForm.js it is assumed that there is neither a query segment nor a fragment segment in the action param of the form. But when using translatable there is the locale appended to the path. So when some path segments get append to the action value they end up after the query segment which causes the ajax request to fail.
