### PR TITLE
Fix for array to string conversion error with File Upload Fields

### DIFF
--- a/code/model/UserDefinedForm.php
+++ b/code/model/UserDefinedForm.php
@@ -799,6 +799,11 @@ JS
 				}
 			}
 			
+			//$submittedField->Value is being saved into DB as a string so never try to save an array as the value. Fixes https://github.com/silverstripe/silverstripe-userforms/issues/86
+			if( is_array($submittedField->Value) ){
+				$submittedField->Value = null;
+			}
+			
 			if(!$this->DisableSaveSubmissions) $submittedField->write();
 	
 			$submittedFields->push($submittedField);


### PR DESCRIPTION
Fixes the issue with userforms fileupload fields trying to save the value as an array and the SS core throwing an error.
Issue explained in https://github.com/silverstripe/silverstripe-userforms/issues/86
