### PR TITLE
BUG: Fix access to static configuration variables

### DIFF
--- a/code/formfields/FieldEditor.php
+++ b/code/formfields/FieldEditor.php
@@ -8,7 +8,7 @@
 
 class FieldEditor extends FormField {
 
-	public static $allowed_actions = array(
+	private static $allowed_actions = array(
 		'addfield',
 		'addoptionfield'
 	);
@@ -102,7 +102,7 @@ class FieldEditor extends FormField {
 			$output = new ArrayList();
 			foreach($fields as $field => $title) {
 				// get the nice title and strip out field
-				$niceTitle = trim(eval("return $title::\$singular_name;")); 
+				$niceTitle = Config::inst()->get($title, 'singular_name');
 				if($niceTitle) {
 					$output->push(new ArrayData(array(
 						'ClassName' => $field,

--- a/code/model/UserDefinedForm.php
+++ b/code/model/UserDefinedForm.php
@@ -74,11 +74,11 @@ class UserDefinedForm extends Page {
 		$editor->setRows(3);
 		$label->addExtraClass('left');		
 
-		UserDefinedForm_EmailRecipient::$summary_fields = array(
+		UserDefinedForm_EmailRecipient::set_summary_fields(array(
 			'EmailAddress' => _t('UserDefinedForm.EMAILADDRESS', 'Email'),
 			'EmailSubject' => _t('UserDefinedForm.EMAILSUBJECT', 'Subject'),
 			'EmailFrom' => _t('UserDefinedForm.EMAILFROM', 'From')
-		);
+		));
 
 		// who do we email on submission
 		$emailRecipients = new GridField("EmailRecipients", _t('UserDefinedForm.EMAILRECIPIENTS', 'Email Recipients'), $this->EmailRecipients(), GridFieldConfig_RecordEditor::create(10));
@@ -1016,7 +1016,7 @@ JS
  */
 class UserDefinedForm_EmailRecipient extends DataObject {
 	
-	public static $db = array(
+	private static $db = array(
 		'EmailAddress' => 'Varchar(200)',
 		'EmailSubject' => 'Varchar(200)',
 		'EmailFrom' => 'Varchar(200)',
@@ -1026,12 +1026,23 @@ class UserDefinedForm_EmailRecipient extends DataObject {
 		'HideFormData' => 'Boolean'
 	);
 	
-	public static $has_one = array(
+	private static $has_one = array(
 		'Form' => 'UserDefinedForm',
 		'SendEmailFromField' => 'EditableFormField',
 		'SendEmailToField' => 'EditableFormField'
 	);
 	
+	private static $summary_fields = array();
+
+	/**
+	 * Expose the summary_fields static
+	 * 
+	 * @param array $fields
+	 */
+	public static function set_summary_fields($fields) {
+				self::$summary_fields = $fields;
+	}
+
 	/**
 	 * @return FieldList
 	 */

--- a/code/model/formfields/EditableCheckbox.php
+++ b/code/model/formfields/EditableCheckbox.php
@@ -9,9 +9,9 @@
 
 class EditableCheckbox extends EditableFormField {
 	
-	static $singular_name = 'Checkbox Field';
+	private static $singular_name = 'Checkbox Field';
 	
-	static $plural_name = 'Checkboxes';
+	private static $plural_name = 'Checkboxes';
 	
 	public function getFieldConfiguration() {
 		$options = parent::getFieldConfiguration();

--- a/code/model/formfields/EditableCheckboxGroupField.php
+++ b/code/model/formfields/EditableCheckboxGroupField.php
@@ -9,9 +9,9 @@
 
 class EditableCheckboxGroupField extends EditableMultipleOptionField {
 
-	static $singular_name = "Checkbox Group";
+	private static $singular_name = "Checkbox Group";
 	
-	static $plural_name = "Checkbox Groups";
+	private static $plural_name = "Checkbox Groups";
 	
 	public function getFormField() {
 		$optionSet = $this->Options();

--- a/code/model/formfields/EditableDateField.php
+++ b/code/model/formfields/EditableDateField.php
@@ -9,9 +9,9 @@
 
 class EditableDateField extends EditableFormField {
 	
-	static $singular_name = 'Date Field';
+	private static $singular_name = 'Date Field';
 	
-	static $plural_name = 'Date Fields';
+	private static $plural_name = 'Date Fields';
 	
 	public function getFieldConfiguration() {
 		$default = ($this->getSetting('DefaultToToday')) ? $this->getSetting('DefaultToToday') : false;

--- a/code/model/formfields/EditableDropdown.php
+++ b/code/model/formfields/EditableDropdown.php
@@ -9,9 +9,9 @@
 
 class EditableDropdown extends EditableMultipleOptionField {
 	
-	static $singular_name = 'Dropdown Field';
+	private static $singular_name = 'Dropdown Field';
 	
-	static $plural_name = 'Dropdowns';
+	private static $plural_name = 'Dropdowns';
 	
 	/**
 	 * @return DropdownField

--- a/code/model/formfields/EditableEmailField.php
+++ b/code/model/formfields/EditableEmailField.php
@@ -9,9 +9,9 @@
 
 class EditableEmailField extends EditableFormField {
 	
-	static $singular_name = 'Email Field';
+	private static $singular_name = 'Email Field';
 	
-	static $plural_name = 'Email Fields';
+	private static $plural_name = 'Email Fields';
 	
 	public function getFormField() {
 		return new EmailField($this->Name, $this->Title);

--- a/code/model/formfields/EditableFileField.php
+++ b/code/model/formfields/EditableFileField.php
@@ -8,9 +8,9 @@
 
 class EditableFileField extends EditableFormField {
 	
-	public static $singular_name = 'File Upload Field';
+	private static $singular_name = 'File Upload Field';
 	
-	public static $plural_names = 'File Fields';
+	private static $plural_names = 'File Fields';
 	
 	public function getFormField() {
 		$field = new FileField($this->Name, $this->Title);

--- a/code/model/formfields/EditableFormField.php
+++ b/code/model/formfields/EditableFormField.php
@@ -8,7 +8,7 @@
 
 class EditableFormField extends DataObject {
 	
-	static $default_sort = "Sort";
+	private static $default_sort = "Sort";
 	
 	/**
 	 * A list of CSS classes that can be added
@@ -17,7 +17,7 @@ class EditableFormField extends DataObject {
 	 */
 	public static $allowed_css = array();
 	
-	static $db = array(
+	private static $db = array(
 		"Name" => "Varchar",
 		"Title" => "Varchar(255)",
 		"Default" => "Varchar",
@@ -29,11 +29,11 @@ class EditableFormField extends DataObject {
 		"CustomParameter" => "Varchar(200)"
 	);
 
-	static $has_one = array(
+	private static $has_one = array(
 		"Parent" => "UserDefinedForm",
 	);
 	
-	static $extensions = array(
+	private static $extensions = array(
 		"Versioned('Stage', 'Live')"
 	);
 	

--- a/code/model/formfields/EditableFormHeading.php
+++ b/code/model/formfields/EditableFormHeading.php
@@ -7,9 +7,9 @@
 
 class EditableFormHeading extends EditableFormField {
 
-	static $singular_name = 'Heading';
+	private static $singular_name = 'Heading';
 	
-	static $plural_name = 'Headings';
+	private static $plural_name = 'Headings';
 	
 	public function getFieldConfiguration() {
 		$levels = array(

--- a/code/model/formfields/EditableLiteralField.php
+++ b/code/model/formfields/EditableLiteralField.php
@@ -9,9 +9,9 @@
 
 class EditableLiteralField extends EditableFormField {
 	
-	static $singular_name = 'HTML Block';
+	private static $singular_name = 'HTML Block';
 	
-	static $plural_name = 'HTML Blocks';
+	private static $plural_name = 'HTML Blocks';
 	
 	public function getFieldConfiguration() {
 		$customSettings = unserialize($this->CustomSettings);	

--- a/code/model/formfields/EditableMemberListField.php
+++ b/code/model/formfields/EditableMemberListField.php
@@ -7,9 +7,9 @@
 
 class EditableMemberListField extends EditableFormField {
 	
-	static $singular_name = 'Member List Field';
+	private static $singular_name = 'Member List Field';
 	
-	static $plural_name = 'Member List Fields';
+	private static $plural_name = 'Member List Fields';
 	
 	public function getFieldConfiguration() {
 		$groupID = ($this->getSetting('GroupID')) ? $this->getSetting('GroupID') : 0;

--- a/code/model/formfields/EditableMultipleOptionField.php
+++ b/code/model/formfields/EditableMultipleOptionField.php
@@ -15,7 +15,7 @@
 
 class EditableMultipleOptionField extends EditableFormField {
 	
-	static $has_many = array(
+	private static $has_many = array(
 		"Options" => "EditableOption"
 	);
 	

--- a/code/model/formfields/EditableOption.php
+++ b/code/model/formfields/EditableOption.php
@@ -9,20 +9,20 @@
 
 class EditableOption extends DataObject {
 	
-	static $default_sort = "Sort";
+	private static $default_sort = "Sort";
 
-	static $db = array(
+	private static $db = array(
 		"Name" => "Varchar(255)",
 		"Title" => "Varchar(255)",
 		"Default" => "Boolean",
 		"Sort" => "Int"
 	);
 	
-	static $has_one = array(
+	private static $has_one = array(
 		"Parent" => "EditableMultipleOptionField",
 	);
 	
-	static $extensions = array(
+	private static $extensions = array(
 		"Versioned('Stage', 'Live')"
 	);
 

--- a/code/model/formfields/EditableRadioField.php
+++ b/code/model/formfields/EditableRadioField.php
@@ -9,9 +9,9 @@
 
 class EditableRadioField extends EditableMultipleOptionField {
 	
-	static $singular_name = 'Radio field';
+	private static $singular_name = 'Radio field';
 	
-	static $plural_name = 'Radio fields';
+	private static $plural_name = 'Radio fields';
 	
 	public function getFormField() {
 		$optionSet = $this->Options();

--- a/code/model/formfields/EditableTextField.php
+++ b/code/model/formfields/EditableTextField.php
@@ -9,9 +9,9 @@
 
 class EditableTextField extends EditableFormField {
 
-	static $singular_name = 'Text Field';
+	private static $singular_name = 'Text Field';
 	
-	static $plural_name = 'Text Fields';
+	private static $plural_name = 'Text Fields';
 	
 	public function getFieldConfiguration() {
 		$fields = parent::getFieldConfiguration();

--- a/code/model/submissions/SubmittedFileField.php
+++ b/code/model/submissions/SubmittedFileField.php
@@ -9,7 +9,7 @@
 
 class SubmittedFileField extends SubmittedFormField {
 	
-	public static $has_one = array(
+	private static $has_one = array(
 		"UploadedFile" => "File"
 	);
 	

--- a/code/model/submissions/SubmittedForm.php
+++ b/code/model/submissions/SubmittedForm.php
@@ -7,16 +7,16 @@
 
 class SubmittedForm extends DataObject {
 	
-	public static $has_one = array(
+	private static $has_one = array(
 		"SubmittedBy" => "Member",
 		"Parent" => "UserDefinedForm",
 	);
 	
-	public static $has_many = array( 
+	private static $has_many = array( 
 		"Values" => "SubmittedFormField"
 	);
 
-	public static $summary_fields = array(
+	private static $summary_fields = array(
 		'ID',
 		'Created'
 	);

--- a/code/model/submissions/SubmittedFormField.php
+++ b/code/model/submissions/SubmittedFormField.php
@@ -7,17 +7,17 @@
 
 class SubmittedFormField extends DataObject {
 	
-	public static $db = array(
+	private static $db = array(
 		"Name" => "Varchar",
 		"Value" => "Text",
 		"Title" => "Varchar(255)"
 	);
 	
-	public static $has_one = array(
+	private static $has_one = array(
 		"Parent" => "SubmittedForm"
 	);
 
-	public static $summary_fields = array(
+	private static $summary_fields = array(
 		'Title',
 		'FormattedValue' => 'Value'
 	);


### PR DESCRIPTION
- Make statics private
- Use Config::get rather than eval to read private statics
- Add a helper function to expose UserDefinedForm_EmailRecipient::$summary_fields
  (to make them available for i18n).
