### PR TITLE
Restore the EditableCountryDropdownField class

### DIFF
--- a/code/model/formfields/EditableCountryDropdownField.php
+++ b/code/model/formfields/EditableCountryDropdownField.php
@@ -1,0 +1,28 @@
+<?php
+
+/**
+ * A dropdown field which allows the user to select a country
+ *
+ * @package userforms
+ */
+class EditableCountryDropdownField extends EditableFormField {
+
+	static $singular_name = 'Country Dropdown';
+	
+	static $plural_name = 'Country Dropdowns';
+	
+	public function getFormField() {
+		return new CountryDropdownField($this->Name, $this->Title);
+	}
+	
+	public function getValueFromData($data) {
+		if(isset($data[$this->Name])) {
+			
+			return Geoip::countryCode2name($data[$this->Name]);
+		}
+	}
+	
+	public function getIcon() {
+		return 'userforms/images/editabledropdown.png';
+	}
+}


### PR DESCRIPTION
Reverts "MINOR Removed the country dropdown field due to the framework
has removed the CountryDropdownField"

This reverts commit cbe1dce4ff08476a19e4bdea9d12da4e6cd55ad0.

Framework has not, in fact, removed CountryDropdownField. This commit
restores the EditableCountryDropdownField class.
