### PR TITLE
userforms.yml: changed FieldEditor.js to UserForm.js (Issue #126)

### DIFF
--- a/_config/userforms.yml
+++ b/_config/userforms.yml
@@ -3,7 +3,7 @@ name: userforms
 ---
 LeftAndMain:
   extra_requirements_javascript:
-    - userforms/javascript/FieldEditor.js
+    - userforms/javascript/UserForm.js
 
   extra_requirements_css:
     - userforms/css/FieldEditor.css


### PR DESCRIPTION
Since the FieldEditor.js is replaced by UserForm.js, userforms.yml should point to that file.
