### PR TITLE
Fix duplication of custom rules.

### DIFF
--- a/code/model/UserDefinedForm.php
+++ b/code/model/UserDefinedForm.php
@@ -46,6 +46,13 @@ class UserDefinedForm extends Page {
 		"EmailRecipients" => "UserDefinedForm_EmailRecipient"
 	);
 	
+    /**
+     * Temporary storage of field ids when the form is duplicated.
+     * Example layout: array('EditableCheckbox3' => 'EditableCheckbox14')
+     * @var array
+     */
+	protected $fieldsFromTo = array();
+
 	/**
 	 * @return FieldList
 	 */
@@ -281,6 +288,16 @@ class UserDefinedForm extends Page {
 		return $recipients;
 	}
 
+
+	/**
+	 * Store new and old ids of duplicated fields.
+	 * This method also serves as a hook for descendant classes.
+	 */
+	protected function afterDuplicateField($page, $fromField, $toField) {
+		$this->fieldsFromTo[$fromField->ClassName . $fromField->ID] = $toField->ClassName . $toField->ID;
+	}
+
+
 	/**
 	 * Duplicate this UserDefinedForm page, and its form fields.
 	 * Submissions, on the other hand, won't be duplicated.
@@ -296,6 +313,7 @@ class UserDefinedForm extends Page {
 				$newField = $field->duplicate();
 				$newField->ParentID = $page->ID;
 				$newField->write();
+				$this->afterDuplicateField($page, $field, $newField);
 			}
 		}
 		
@@ -308,6 +326,25 @@ class UserDefinedForm extends Page {
 			}
 		}
 		
+		// Rewrite CustomRules
+		if ($page->Fields()) {
+			foreach($page->Fields() as $field) {
+				// Rewrite name to make the CustomRules-rewrite below work.
+				// UserDefinedForm waits untill 'publish' to rewrite the name?
+				$field->Name = $field->ClassName . $field->ID;
+				// Rewrite the CustomRules
+				$rules = unserialize($field->CustomRules);
+				if (count($rules) && isset($rules[0]['ConditionField'])) {
+					$from = $rules[0]['ConditionField'];
+					if (array_key_exists($from, $this->fieldsFromTo)) {
+						$rules[0]['ConditionField'] = $this->fieldsFromTo[$from];
+						$field->CustomRules = serialize($rules);
+					}
+				}
+				$field->Write();
+			}
+		}
+
 		return $page;
 	}
 


### PR DESCRIPTION
Rules may depend on fields.  These internal field IDs in the targets now
also get updated to their new names (GitHub: #19).
