### PR TITLE
Remove title from email template

### DIFF
--- a/templates/email/SubmittedFormEmail.ss
+++ b/templates/email/SubmittedFormEmail.ss
@@ -1,4 +1,3 @@
-<h1>$Subject</h1>
 $Body
 
 <% if HideFormData %>


### PR DESCRIPTION
If this is here, there's no way for us to generate an email that's not horribly ugly (short of custom CSS / templates).

This allows users of the standard module to decide _exactly_ what content goes into an email without dealing with forking/customizing the code.

This will be a minor BC break.
