### PR TITLE
Change dependency versions to work for 3.1.0-rc1.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -9,7 +9,7 @@
 		"email": "will@fullscreen.io"
 	}],
 	"require": {
-		"silverstripe/framework": ">=3.1.x-dev,<4.0",
-		"silverstripe/cms": ">=3.1.x-dev,<4.0"
+		"silverstripe/framework": "3.1.*,<4.0",
+		"silverstripe/cms": "3.1.*,<4.0"
 	}
 }


### PR DESCRIPTION
minimum-stability on the requiring package is better suited for control
over the stability, and this will allow us to provide an unstable
version for the silverstripe/framework pegged to 3.1.0-rc1.
