### PR TITLE
Fix/script timeout csv

### DIFF
--- a/code/formfields/SubmittedFormReportField.php
+++ b/code/formfields/SubmittedFormReportField.php
@@ -77,6 +77,8 @@ class SubmittedFormReportField extends FormField {
 	 * @return HTTPResponse / bool
 	 */
 	public function export($id = false) {
+		// The default max execution time is sometimes not enough for large number of submissions
+		increase_time_limit_to(600);
 		if($id && is_int($id)) {
 			$SQL_ID = $id;
 		}


### PR DESCRIPTION
For 1000+ submissions, the export takes more than 30 seconds and fails with a fatal error. This fixes the issue.
