### PR TITLE
FIX submitted fieldfields in submission details in CMS

### DIFF
--- a/code/model/submissions/SubmittedFileField.php
+++ b/code/model/submissions/SubmittedFileField.php
@@ -25,10 +25,10 @@ class SubmittedFileField extends SubmittedFormField {
 		$title = _t('SubmittedFileField.DOWNLOADFILE', 'Download File');
 		
 		if($link) {
-			return sprintf(
+			return DBField::create_field('HTMLText', sprintf(
 				'%s - <a href="%s" target="_blank">%s</a>', 
 				$name, $link, $title
-			);
+			));
 		}
 		
 		return false;

--- a/code/model/submissions/SubmittedFormField.php
+++ b/code/model/submissions/SubmittedFormField.php
@@ -18,7 +18,7 @@ class SubmittedFormField extends DataObject {
 	);
 
 	private static $summary_fields = array(
-		'Title',
+		'Title' => 'Title',
 		'FormattedValue' => 'Value'
 	);
 


### PR DESCRIPTION
If you had a EditableFileField in your userform, the submission table in
the CMS would just say "Array" rather than link to the file
