### PR TITLE
FIX: Ensure that the data-add-url single quotes are not processed by join_links

### DIFF
--- a/code/formfields/FieldEditor.php
+++ b/code/formfields/FieldEditor.php
@@ -19,7 +19,7 @@ class FieldEditor extends FormField {
 	 * @return String
 	 */
 	public function FieldHolder($properties = array()) {
-		$this->setAttribute('data-add-url', '\''.Controller::join_links($this->Link('addfield').'\''));
+		$this->setAttribute('data-add-url', '\''.Controller::join_links($this->Link('addfield')).'\'');
 		return $this->renderWith("FieldEditor");
 	}
 	


### PR DESCRIPTION
Due to the position of  the second to last bracket, join_links was actually sent URL + ' (eg; http://myurl.com' ), this caused problems when the quote was getting escaped - and actually prevented users from adding form fields in the CMS, with a 500. 
