### PR TITLE
Escaped addField() query to work with Postgres

### DIFF
--- a/code/formfields/FieldEditor.php
+++ b/code/formfields/FieldEditor.php
@@ -188,9 +188,9 @@ class FieldEditor extends FormField {
 			
 			$sqlQuery = new SQLQuery();
 			$sqlQuery = $sqlQuery
-				->setSelect('MAX(Sort)')
-				->setFrom("EditableFormField")
-				->setWhere("ParentID = $parentID");
+				->setSelect("MAX(\"Sort\")")
+				->setFrom("\"EditableFormField\"")
+				->setWhere("\"ParentID\" = $parentID");
 
 			$sort = $sqlQuery->execute()->value() + 1;
 


### PR DESCRIPTION
I was getting a warning in the CMS with a Postgres database due to the fields on lines 191 - 193 not being double quoted.
