### PR TITLE
BUG Performance improvements of SubmittedFormField queries.

### DIFF
--- a/code/UserFormsGridFieldFilterHeader.php
+++ b/code/UserFormsGridFieldFilterHeader.php
@@ -8,7 +8,17 @@
  * @package userforms
  */
 class UserFormsGridFieldFilterHeader extends GridFieldFilterHeader {
-	
+
+	/**
+	 * A map of name => value of columns from all submissions
+	 * @var array
+	 */
+	protected $columns;
+
+	public function setColumns($columns) {
+		$this->columns = $columns;
+	}
+
 	public function handleAction(GridField $gridField, $actionName, $arguments, $data) {
 		if(!$this->checkDataType($gridField->getList())) {
 			return;
@@ -36,18 +46,10 @@ class UserFormsGridFieldFilterHeader extends GridFieldFilterHeader {
 		// submitted in this form.
 		$params = $gridField->getForm()->getController()->getURLParams();
 
-		// this is for you SQL server I know you don't see '' as a number
-		$parentID = (!empty($params['ID'])) ? Convert::raw2sql($params['ID']) : 0;
-		$formFields = SubmittedFormField::get()
-			->where(sprintf("SubmittedForm.ParentID = '%s'", $parentID))
-			->leftJoin('SubmittedForm', 'SubmittedFormField.ParentID = SubmittedForm.ID')
-			->sort('Title', 'ASC')
-			->map('Name', 'Title');
-
 		// show dropdown of all the fields available from the submitted form fields
 		// that have been saved. Takes the titles from the currently live form.
 		$columnField = new DropdownField('FieldNameFilter', '');
-		$columnField->setSource($formFields->toArray());
+		$columnField->setSource($this->columns);
 		$columnField->setEmptyString(_t('UserFormsGridFieldFilterHeader.FILTERSUBMISSIONS', 'Filter Submissions..'));
 		$columnField->setHasEmptyDefault(true);
 		$columnField->setValue($selectedField);


### PR DESCRIPTION
When there are a lot of SubmittedForm records the UserDefinedForm
page takes a long time to load in the CMS, and oftens exceeds
the PHP memory limit well beyond 128M.

Previously UserDefinedForm::getCMSFields() would build a list of
name => value from all SubmittedFormField records, but it would
do this twice, once in getCMSFields() and another time in
UserFormsGridFieldFilterHeader. It would also use the full ORM
to build this list, when all it needs is a map of the Name
and Value columns.

This fixes that to build the columns once in getCMSFields() using
DB::query() and it'll pass those columns along to
UserFormsGridFieldFilterHeader as well so it doesn't do it twice.
