### PR TITLE
Enable extensions to add CMS fields to FieldConfiguration and FieldValidation of EditableFormField

### DIFF
--- a/code/model/formfields/EditableFormField.php
+++ b/code/model/formfields/EditableFormField.php
@@ -415,11 +415,14 @@ class EditableFormField extends DataObject {
 			_t('EditableFormField.RIGHTTITLE', 'Right Title'), 
 			$this->getSetting('RightTitle')
 		);
-			
-		return new FieldList(
-			$ec,
-			$right
-		);
+
+        $fields = FieldList::create(
+            $ec,
+            $right
+        );
+        $this->extend('updateFieldConfiguration', $fields);
+        
+        return $fields;
 	}
 	
 	/**
@@ -439,6 +442,8 @@ class EditableFormField extends DataObject {
 				$field->performReadonlyTransformation();
 			}
 		}
+
+        $this->extend('updateFieldValidationOptions', $fields);
 		
 		return $fields;
 	}

--- a/tests/UserDefinedFormTest.yml
+++ b/tests/UserDefinedFormTest.yml
@@ -103,6 +103,14 @@ EditableRadioField:
         Options: =>EditableOption.option-5, =>EditableOption.option-6
 
 
+ExtendedEditableFormField:
+    extended-field:
+        Name: extended-field
+        Title: Extended Field
+        TestExtraField: Extra Field
+        TestValidationField: Extra Validation Field
+
+
 UserDefinedForm:
     basic-form-page:
         Title: User Defined Form
@@ -123,6 +131,5 @@ UserDefinedForm:
         Fields: =>EditableCheckbox.checkbox-2, =>EditableTextField.basic-text-2
     empty-form:
         Title: Empty Form
-        
         
         


### PR DESCRIPTION
This was modified as a way to stop devs from changing the getFieldConfiguration and getFieldValidationOptions functions willy-nilly, and kept on a local fork. I thought the upstream repository could also do with the functionality, so I added some unit tests and here it is. 

Let me know if you need anything changed or have any questions.
