### PR TITLE
BUG: Fixes #69 by adding a check to see if the form has been processed

### DIFF
--- a/code/model/UserDefinedForm.php
+++ b/code/model/UserDefinedForm.php
@@ -1046,8 +1046,11 @@ JS
 		
 		$referrer = (isset($data['Referrer'])) ? '?referrer=' . urlencode($data['Referrer']) : "";
 
+
 		// set a session variable from the security ID to stop people accessing the finished method directly
-		Session::set('FormProcessed',$data['SecurityID']);
+		if (isset($data['SecurityID'])) {
+			Session::set('FormProcessed',$data['SecurityID']);
+		}
 		
 		return $this->redirect($this->Link() . 'finished' . $referrer);
 	}
@@ -1059,25 +1062,21 @@ JS
 	 * @return ViewableData
 	 */
 	public function finished() {
+		$referrer = isset($_GET['referrer']) ? urldecode($_GET['referrer']) : null;
+		
 		$formProcessed = Session::get('FormProcessed');
 		if (!isset($formProcessed)) {
-				$referrer = (isset($data['Referrer'])) ? '?referrer=' .
-					urlencode($data['Referrer']) : "";
 				return $this->redirect($this->Link() . $referrer);
 		} else {
 			$securityID = Session::get('SecurityID');
 			// make sure the session matches the SecurityID and is not left over from another form
 			if ($formProcessed != $securityID) {
-				$referrer = (isset($data['Referrer'])) ? '?referrer=' .
-					urlencode($data['Referrer']) : "";
 				return $this->redirect($this->Link() . $referrer);
 			}
 		}
 		// remove the session variable as we do not want it to be re-used
 		Session::clear('FormProcessed');
 
-		$referrer = isset($_GET['referrer']) ? urldecode($_GET['referrer']) : null;
-		
 		return $this->customise(array(
 			'Content' => $this->customise(
 				array(

--- a/tests/UserDefinedFormControllerTest.php
+++ b/tests/UserDefinedFormControllerTest.php
@@ -59,9 +59,26 @@ class UserDefinedFormControllerTest extends FunctionalTest {
 	
 	function testFinished() {
 		$form = $this->setupFormFrontend();
+
+		// set formProcessed and SecurityID to replicate the form being filled out
+		$this->session()->inst_set('SecurityID', 1);
+		$this->session()->inst_set('FormProcessed', 1);
+
 		$response = $this->get($form->URLSegment.'/finished');
 		
 		$this->assertContains($form->OnCompleteMessage ,$response->getBody());
+	}
+
+	function testAppendingFinished() {
+		$form = $this->setupFormFrontend();
+
+		// replicate finished being added to the end of the form URL without the form being filled out
+		$this->session()->inst_set('SecurityID', 1);
+		$this->session()->inst_set('FormProcessed', null);
+
+		$response = $this->get($form->URLSegment.'/finished');
+		
+		$this->assertNotContains($form->OnCompleteMessage ,$response->getBody());
 	}
 	
 	function testForm() {


### PR DESCRIPTION
This fixes the issue of being able to browse to the form submission confirmation page by appending finished to the URL.
It works by setting a session variable which contains the Security ID just before redirecting to the confirmation page.
When the finished method is called it checks if the session variable is set and that it matches the SecurityID if these criteria are not met it redirects back to the form page.
