### PR TITLE
Update FieldEditor.php

### DIFF
--- a/code/formfields/FieldEditor.php
+++ b/code/formfields/FieldEditor.php
@@ -127,7 +127,7 @@ class FieldEditor extends FormField {
 					$title
 				);
 
-				if($niceTitle) {
+				if($niceTitle && $field != "EditableMultipleOptionField") {
 					$output->push(new ArrayData(array(
 						'ClassName' => $field,
 						'Title' => "$niceTitle"


### PR DESCRIPTION
The EditableMultipleOptionField is being exposed in the form builder, when it is added to the form the page dies! It needs to be excluded.
