### PR TITLE
NEW: Add a check + error message if input vars is exceded

### DIFF
--- a/code/formfields/FieldEditor.php
+++ b/code/formfields/FieldEditor.php
@@ -223,6 +223,16 @@ class FieldEditor extends FormField {
 			$className = (isset($_REQUEST['Type'])) ? $_REQUEST['Type'] : '';
 			
 			if(!$className) {
+				// A possible reason for the classname being blank is because we have execeded
+				// the number of input requests
+				// http://www.php.net/manual/en/info.configuration.php#ini.max-input-vars
+				$maxRequests = ini_get('max_input_vars');
+				$numRequests = count($_REQUEST, COUNT_RECURSIVE);
+				if ($numRequests > $maxRequests) {
+					$error = sprintf('You have exceded the maximum number %s of input requests',
+						"[$maxRequests]");
+					user_error($error, E_USER_WARNING);
+				}
 				user_error('Please select a field type to created', E_USER_WARNING);
 			}
 


### PR DESCRIPTION
This pull request just adds a check and error message to see if the number of $_REQUEST variables excedes the number of max_input_vars set for PHP.
Tested by creating a large userform in the admin error and seeing the error produced when trying to add another field.

It is also worth considering that the userforms module will not be able to create a front end form that gets close to exceeding the maximum number of input variables due to the cms/framework overhead and the form fields used for the options, this is not a bad thing as it is a bad user experience to have a massive form to fill out, but a future enhancement may be to split or create large forms into smaller sections so for example a form with 30 input fields could be split over 3 form pages of 10 input each with a final confirmation submission.
