### PR TITLE
NEW: Allow form submission when tokens are disabled

### DIFF
--- a/code/model/UserDefinedForm.php
+++ b/code/model/UserDefinedForm.php
@@ -1054,6 +1054,15 @@ JS
 		// set a session variable from the security ID to stop people accessing the finished method directly
 		if (isset($data['SecurityID'])) {
 			Session::set('FormProcessed',$data['SecurityID']);
+		} else {
+			// if the form has had tokens disabled we still need to set FormProcessed
+			// to allow us to get through the finshed method
+			if (!$this->Form()->getSecurityToken()->isEnabled()) {
+				$randNum = rand(1, 1000);
+				$randHash = md5($randNum);
+				Session::set('FormProcessed',$randHash);
+				Session::set('FormProcessedNum',$randNum);
+			}
 		}
 		
 		return $this->redirect($this->Link() . 'finished' . $referrer);
@@ -1070,12 +1079,16 @@ JS
 		
 		$formProcessed = Session::get('FormProcessed');
 		if (!isset($formProcessed)) {
-				return $this->redirect($this->Link() . $referrer);
+			return $this->redirect($this->Link() . $referrer);
 		} else {
 			$securityID = Session::get('SecurityID');
 			// make sure the session matches the SecurityID and is not left over from another form
 			if ($formProcessed != $securityID) {
-				return $this->redirect($this->Link() . $referrer);
+				// they may have disabled tokens on the form
+				$securityID = md5(Session::get('FormProcessedNum'));
+				if ($formProcessed != $securityID) {
+					return $this->redirect($this->Link() . $referrer);
+				}
 			}
 		}
 		// remove the session variable as we do not want it to be re-used


### PR DESCRIPTION
If Security tokens are disabled user forms will never reach the finished method as it checks for a session variable of FormProcessed which is only set from the security token.
This patch adds extra checks to see if security tokens are disabled and sets FormProcessed with a random hash which is then confirmed in the finished method.

Tested this by extending UserDefinedForm and calling $form->disableSecurityToken to disable the tokens, to confirm the form can still be submitted.
