### PR TITLE
Put the Columns in the Sort order of the Editable Fields

### DIFF
--- a/code/model/UserDefinedForm.php
+++ b/code/model/UserDefinedForm.php
@@ -118,9 +118,8 @@ class UserDefinedForm extends Page {
 SELECT "SubmittedFormField"."Name", "SubmittedFormField"."Title"
 FROM "SubmittedFormField"
 LEFT JOIN "SubmittedForm" ON "SubmittedForm"."ID" = "SubmittedFormField"."ParentID"
-LEFT JOIN "EditableFormField_Live" ON "EditableFormField_Live"."ParentID" = "SubmittedForm"."ParentID"
 WHERE "SubmittedForm"."ParentID" = '$parentID'
-ORDER BY "EditableFormField_Live"."Sort" ASC
+ORDER BY "SubmittedFormField"."ID" ASC
 SQL;
 		$columns = DB::query($columnSQL)->map();
 


### PR DESCRIPTION
Hey, don't know if anyone else has had this problem but my client wanted the csv to export in the order of the form fields, not in alphabetical order. Which makes sense really.
Here is my dirty fix.  

Signed-off-by: Cameron Grant sasky.creative@gmail.com
