### PR TITLE
Fixed redirect url generation to work without trailing slashes

### DIFF
--- a/code/model/UserDefinedForm.php
+++ b/code/model/UserDefinedForm.php
@@ -1065,7 +1065,7 @@ JS
 			}
 		}
 		
-		return $this->redirect($this->Link() . 'finished' . $referrer);
+		return $this->redirect($this->Link('finished') . $referrer);
 	}
 
 	/**


### PR DESCRIPTION
fix url redirect generation, 
using action parameter on $this->Link() to pass 'complete' action
to stop relying on trailing slashes.
