### PR TITLE
API Support bulk editing tools if available

### DIFF
--- a/code/model/UserDefinedForm.php
+++ b/code/model/UserDefinedForm.php
@@ -136,6 +136,13 @@ SQL;
 		$config->addComponent(new GridFieldDetailForm());
 		$config->addComponent($export = new GridFieldExportButton());
 		$config->addComponent($print = new GridFieldPrintButton());
+		
+		/**
+		 * Support for {@link https://github.com/colymba/GridFieldBulkEditingTools}
+		 */
+		if(class_exists('GridFieldBulkManager')) {
+			$config->addComponent(new GridFieldBulkManager());
+		}
 
 		$sort->setThrowExceptionOnBadDataType(false);
 		$filter->setThrowExceptionOnBadDataType(false);

--- a/composer.json
+++ b/composer.json
@@ -11,5 +11,8 @@
 	"require": {
 		"silverstripe/framework": ">=3.1.0",
 		"silverstripe/cms": ">=3.1.0"
+	},
+	"suggest": {
+		"colymba/gridfield-bulk-editing-tools": "Allows for bulk management of form submissions"
 	}
 }


### PR DESCRIPTION
For forms with many submissions it may be necessary to delete many items in one go. If the bulk management tools are installed, then it would be a reasonable enhancement to automatically enable it for submissions.
