### PR TITLE
Extra Space at line 1018 of UserDefinedForm.php

### DIFF
--- a/code/model/UserDefinedForm.php
+++ b/code/model/UserDefinedForm.php
@@ -1015,7 +1015,7 @@ JS
 				$this->extend('updateEmail', $email, $recipient, $emailData);
 
 				if($recipient->SendPlain) {
-					$body = strip_tags($recipient->EmailBody) . "\n ";
+					$body = strip_tags($recipient->EmailBody) . "\n";
 					if(isset($emailData['Fields']) && !$recipient->HideFormData) {
 						foreach($emailData['Fields'] as $Field) {
 							$body .= $Field->Title .' - '. $Field->Value ." \n";


### PR DESCRIPTION
When a user chose the Plain Text option, the first field would have a blank space preceding the field name.
