### PR TITLE
remove unnecessary call to getURLParams()

### DIFF
--- a/code/UserFormsGridFieldFilterHeader.php
+++ b/code/UserFormsGridFieldFilterHeader.php
@@ -41,11 +41,7 @@ class UserFormsGridFieldFilterHeader extends GridFieldFilterHeader {
 
 		$selectedField = $state->filter;
 		$selectedValue = $state->value;
-
-		// retrieve a list of all the available form fields that have been 
-		// submitted in this form.
-		$params = $gridField->getForm()->getController()->getURLParams();
-
+		
 		// show dropdown of all the fields available from the submitted form fields
 		// that have been saved. Takes the titles from the currently live form.
 		$columnField = new DropdownField('FieldNameFilter', '');


### PR DESCRIPTION
The result of getURLParams was never used / cleaned up -- and it breaks the ability to edit a UserDefinedForm in a GridField.  (eg via the holderpage or versioned-gridfield module)
