### PR TITLE
Fixing and adding form field custom error messages code.

### DIFF
--- a/code/model/formfields/EditableCheckbox.php
+++ b/code/model/formfields/EditableCheckbox.php
@@ -21,7 +21,18 @@ class EditableCheckbox extends EditableFormField {
 	}
 	
 	public function getFormField() {
-		return new CheckboxField( $this->Name, $this->Title, $this->getSetting('Default'));
+		
+		$field = CheckboxField::create( $this->Name, $this->Title, $this->getSetting('Default'));
+		
+		if ($this->Required) {
+			// Required validation can conflict so add the Required validation messages
+			// as input attributes
+			$errorMessage = $this->getErrorMessage()->HTML();
+			$field->setAttribute('data-rule-required', 'true');
+			$field->setAttribute('data-msg-required', $errorMessage);
+		}
+		
+		return $field;
 	}
 	
 	public function getValueFromData($data) {

--- a/code/model/formfields/EditableDateField.php
+++ b/code/model/formfields/EditableDateField.php
@@ -38,9 +38,17 @@ class EditableDateField extends EditableFormField {
 	 */
 	public function getFormField() {
 		$defaultValue = ($this->getSetting('DefaultToToday')) ? date('Y-m-d') : $this->Default;
-		$field = new EditableDateField_FormField( $this->Name, $this->Title, $defaultValue);
+		$field = EditableDateField_FormField::create( $this->Name, $this->Title, $defaultValue);
 		$field->setConfig('showcalendar', true);
 
+		if ($this->Required) {
+			// Required validation can conflict so add the Required validation messages
+			// as input attributes
+			$errorMessage = $this->getErrorMessage()->HTML();
+			$field->setAttribute('data-rule-required', 'true');
+			$field->setAttribute('data-msg-required', $errorMessage);
+		}
+		
 		return $field;
 	}
 }

--- a/code/model/formfields/EditableDropdown.php
+++ b/code/model/formfields/EditableDropdown.php
@@ -26,6 +26,16 @@ class EditableDropdown extends EditableMultipleOptionField {
 			}
 		}
 		
-		return new DropdownField($this->Name, $this->Title, $options);	
+		$field = DropdownField::create($this->Name, $this->Title, $options);
+
+		if ($this->Required) {
+			// Required validation can conflict so add the Required validation messages
+			// as input attributes
+			$errorMessage = $this->getErrorMessage()->HTML();
+			$field->setAttribute('data-rule-required', 'true');
+			$field->setAttribute('data-msg-required', $errorMessage);
+		}
+		
+		return $field;
 	}
 }

--- a/code/model/formfields/EditableEmailField.php
+++ b/code/model/formfields/EditableEmailField.php
@@ -18,16 +18,18 @@ class EditableEmailField extends EditableFormField {
 	}
 	
 	public function getFormField() {
+		
+		$field = EmailField::create($this->Name, $this->Title);
+		
 		if ($this->Required) {
-			//  Required and Email validation can conflict so add the Required validation messages
+			// Required and Email validation can conflict so add the Required validation messages
 			// as input attributes
 			$errorMessage = $this->getErrorMessage()->HTML();
-			$field =  new EmailField($this->Name, $this->Title);
-			$field->setAttribute('data-rule-required','true');
-			$field->setAttribute('data-msg-required',$errorMessage);
-			return $field;
+			$field->setAttribute('data-rule-required', 'true');
+			$field->setAttribute('data-msg-required', $errorMessage);
 		}
-		return new EmailField($this->Name, $this->Title);
+		
+		return $field;
 	}
 	
 	/**

--- a/code/model/formfields/EditableFileField.php
+++ b/code/model/formfields/EditableFileField.php
@@ -30,7 +30,7 @@ class EditableFileField extends EditableFormField {
 	}
 
 	public function getFormField() {
-		$field = new FileField($this->Name, $this->Title);
+		$field = FileField::create($this->Name, $this->Title);
 
 		if($this->getSetting('Folder')) {
 			$folder = Folder::get()->byId($this->getSetting('Folder'));
@@ -40,6 +40,14 @@ class EditableFileField extends EditableFormField {
 					preg_replace("/^assets\//","", $folder->Filename)
 				);
 			}
+		}
+
+		if ($this->Required) {
+			// Required validation can conflict so add the Required validation messages
+			// as input attributes
+			$errorMessage = $this->getErrorMessage()->HTML();
+			$field->setAttribute('data-rule-required', 'true');
+			$field->setAttribute('data-msg-required', $errorMessage);
 		}
 
 		return $field;

--- a/code/model/formfields/EditableNumericField.php
+++ b/code/model/formfields/EditableNumericField.php
@@ -24,13 +24,12 @@ class EditableNumericField extends EditableFormField {
 		$field = new NumericField($this->Name, $this->Title);
 		$field->addExtraClass('number');
 
-		if ($field->Required) {
+		if ($this->Required) {
 			// Required and numeric validation can conflict so add the
 			// required validation messages as input attributes
 			$errorMessage = $this->getErrorMessage()->HTML();
-
-			$field->setAttribute('data-rule-required','true');
-			$field->setAttribute('data-msg-required',$errorMessage);
+			$field->setAttribute('data-rule-required', 'true');
+			$field->setAttribute('data-msg-required', $errorMessage);
 		}
 
 		return $field;

--- a/code/model/formfields/EditableTextField.php
+++ b/code/model/formfields/EditableTextField.php
@@ -39,14 +39,26 @@ class EditableTextField extends EditableFormField {
 	 * @return TextareaField|TextField
 	 */
 	public function getFormField() {
+		
+		$field = NULL;
+		
 		if($this->getSetting('Rows') && $this->getSetting('Rows') > 1) {
-			$taf = new TextareaField($this->Name, $this->Title);
-			$taf->setRows($this->getSetting('Rows'));
-			return $taf;
+			$field = TextareaField::create($this->Name, $this->Title);
+			$field->setRows($this->getSetting('Rows'));
 		}
 		else {
-			return new TextField($this->Name, $this->Title, null, $this->getSetting('MaxLength'));
+			$field = TextField::create($this->Name, $this->Title, null, $this->getSetting('MaxLength'));
 		}
+
+		if ($this->Required) {
+			// Required validation can conflict so add the Required validation messages
+			// as input attributes
+			$errorMessage = $this->getErrorMessage()->HTML();
+			$field->setAttribute('data-rule-required', 'true');
+			$field->setAttribute('data-msg-required', $errorMessage);
+		}
+		
+		return $field;
 	}
 	
 	/**


### PR DESCRIPTION
Currently, many of the form field types do not display their custom error message that can be set in the CMS. This code adds the custom messages to the fields for all the field types.
