### PR TITLE
FIX: conditional JS generating wrong field ids

### DIFF
--- a/code/model/UserDefinedForm.php
+++ b/code/model/UserDefinedForm.php
@@ -646,12 +646,8 @@ class UserDefinedForm_Controller extends Page_Controller {
 
 		if($this->Fields()) {
 			foreach($this->Fields() as $field) {
-				$fieldId = $field->Name;
-				
-				if($field->ClassName == 'EditableFormHeading') { 
-					$fieldId = 'Form_Form_'.$field->Name;
-				}
-				
+				$fieldId = 'Form_Form_'.$field->Name.'_Holder';
+								
 				// Is this Field Show by Default
 				if(!$field->getShowOnLoad()) {
 					$default .= "$(\"#" . $fieldId . "\").hide();\n";


### PR DESCRIPTION
Conditional field javascript was generating the incorrect field id's. 

This was breaking in two places:

i. fields set to hide by default were not being hidden.
ii. fields set to conditionally display when another field has a certain value were not being shown.