### PR TITLE
Wrapping getCMSFields fields with beforeUpdateCMSFields

### DIFF
--- a/code/model/submissions/SubmittedForm.php
+++ b/code/model/submissions/SubmittedForm.php
@@ -50,23 +50,29 @@ class SubmittedForm extends DataObject {
 	 * @return FieldList
 	 */
 	public function getCMSFields() {
+		
+		$self = $this;
+		
+		$this->beforeUpdateCMSFields(function($fields) use ($self) {
+			$fields->removeByName('Values');
+			$fields->dataFieldByName('SubmittedByID')->setDisabled(true);
+			
+			$values = new GridField(
+				'Values', 
+				'SubmittedFormField',
+				$self->Values()->sort('Created', 'ASC')
+			);
+			
+			$config = new GridFieldConfig();
+			$config->addComponent(new GridFieldDataColumns());
+			$config->addComponent(new GridFieldExportButton());
+			$config->addComponent(new GridFieldPrintButton());
+			$values->setConfig($config);
+			
+			$fields->addFieldToTab('Root.Main', $values);
+		});
+		
 		$fields = parent::getCMSFields();
-		$fields->removeByName('Values');
-		$fields->dataFieldByName('SubmittedByID')->setDisabled(true);
-
-		$values = new GridField(
-			"Values", 
-			"SubmittedFormField",
-			 $this->Values()->sort('Created', 'ASC')
-		);
-
-		$config = new GridFieldConfig();
-		$config->addComponent(new GridFieldDataColumns());
-		$config->addComponent(new GridFieldExportButton());
-		$config->addComponent(new GridFieldPrintButton());
-		$values->setConfig($config);
-
-		$fields->addFieldToTab('Root.Main', $values);
 		
 		return $fields;
 	}


### PR DESCRIPTION
Wrapping `getCMSFields` fields with `beforeUpdateCMSFields` to allow extensions to run after fields have been added. This is the as per SilverStripe's documentation: 
http://doc.silverstripe.org/en/developer_guides/extending/extensions#object-extension-injection-points