### PR TITLE
Display form fields correctly in email preview

### DIFF
--- a/code/model/UserDefinedForm.php
+++ b/code/model/UserDefinedForm.php
@@ -1377,8 +1377,34 @@ class UserDefinedForm_EmailRecipient_ItemRequest extends GridFieldDetailForm_Ite
 	 */
 	public function preview() {
 		return $this->customise(new ArrayData(array(
-			'Body' => $this->record->getEmailBodyContent()
+			'Body' => $this->record->getEmailBodyContent(),
+			'HideFormData' => $this->record->HideFormData,
+			'Fields' => $this->getPreviewFieldData()
 		)))->renderWith($this->record->EmailTemplate);
+	}
+
+	/**
+	 * Get some placeholder field values to display in the preview
+	 * @return ArrayList
+	 */
+	private function getPreviewFieldData() {
+		$data = new ArrayList();
+
+		$fields = $this->record->Form()->Fields()->filter(array(
+			'ClassName:not' => 'EditableLiteralField',
+			'ClassName:not' => 'EditableFormHeading'
+		));
+
+		foreach ($fields as $field) {
+			$data->push(new ArrayData(array(
+				'Name' => $field->Name,
+				'Title' => $field->Title,
+				'Value' => '$' . $field->Name,
+				'FormattedValue' => '$' . $field->Name
+			)));
+		}
+
+		return $data;
 	}
 }
 


### PR DESCRIPTION
Fix an issue where the 'Hide form data from email?' is not respected in email previews. Also displays placeholder field values in email previews, consistant with merge field placeholders.