### PR TITLE
fix heading fields only being <h> upon creation

### DIFF
--- a/code/model/editableformfields/EditableFormHeading.php
+++ b/code/model/editableformfields/EditableFormHeading.php
@@ -87,4 +87,8 @@ class EditableFormHeading extends EditableFormField {
 	public function getSelectorHolder() {
 		return "$(\":header[data-id='{$this->Name}']\")";
 	}
+
+	public function getLevel() {
+        return $this->getField('Level') ?: 3;
+    }
 }

--- a/templates/Includes/UserFormProgress.ss
+++ b/templates/Includes/UserFormProgress.ss
@@ -1,7 +1,7 @@
 <% if $Steps.Count > 1 %>
 	<div id="userform-progress" class="userform-progress" aria-hidden="true" style="display:none;">
 		<h2 class="progress-title"></h2>
-		<p>Step <span class="current-step-number">1</span> of <span class="total-step-number">$Steps.Count</span></p>
+		<p>Page <span class="current-step-number">1</span> of <span class="total-step-number">$Steps.Count</span></p>
 		<div class="progress">
 			<div class="progress-bar" role="progressbar" aria-valuenow="1" aria-valuemin="1" aria-valuemax="$Steps.Count"></div>
 		</div>


### PR DESCRIPTION
Fix heading fields only being <h> upon creation
Make button sizes more consistent with the rest of the cms
Change text from 'step' to 'page'