### PR TITLE
Fix IE8 drag-and-drop

### DIFF
--- a/css/UserForm_cms.css
+++ b/css/UserForm_cms.css
@@ -4,6 +4,9 @@
 .cms .uf-field-editor {
   padding-bottom: 0;
 }
+.cms .uf-field-editor table.ss-gridfield-table .ss-gridfield-item {
+  height: 46px;
+}
 .cms .uf-field-editor table.ss-gridfield-table .ss-gridfield-item, .cms .uf-field-editor table.ss-gridfield-table .ss-gridfield-item:hover {
   background: white;
 }
@@ -16,6 +19,9 @@
 }
 .cms .uf-field-editor table.ss-gridfield-table .ss-gridfield-item .handle {
   min-height: 46px;
+}
+.cms .uf-field-editor table.ss-gridfield-table .ss-gridfield-item.ui-sortable-placeholder {
+  height: 50px;
 }
 .cms .uf-field-editor table.ss-gridfield-table .ss-gridfield-item.inFieldGroup, .cms .uf-field-editor table.ss-gridfield-table .ss-gridfield-item.inFieldGroup:hover {
   background: #f2f9fd;

--- a/scss/UserForm_cms.scss
+++ b/scss/UserForm_cms.scss
@@ -10,6 +10,8 @@
 		table.ss-gridfield-table {
 			// Standard rows
 			.ss-gridfield-item {
+				height: 46px;
+
 				&, &:hover {
 					background: white;
 				}
@@ -26,6 +28,10 @@
 				.handle {
 					min-height: 46px;
 				}
+			}
+
+			.ss-gridfield-item.ui-sortable-placeholder {
+				height: 50px;
 			}
 
 			.ss-gridfield-item.inFieldGroup {


### PR DESCRIPTION
There's an issue with drag-and-drop in IE8 where fields disappear off the bottom of the page when dragging.

Before:

![ie8-before](https://cloud.githubusercontent.com/assets/878176/9347405/256a6d26-467d-11e5-8207-9e9438087a46.png)

After:

![ie8-after](https://cloud.githubusercontent.com/assets/878176/9347408/2c78cdd8-467d-11e5-9396-fb3125716793.png)
