### PR TITLE
Fix IE8 bottom border on editor

### DIFF
--- a/css/UserForm_cms.css
+++ b/css/UserForm_cms.css
@@ -1,6 +1,9 @@
 /**
  * Styles for cms
  */
+.cms .uf-field-editor {
+  padding-bottom: 0;
+}
 .cms .uf-field-editor table.ss-gridfield-table .ss-gridfield-item, .cms .uf-field-editor table.ss-gridfield-table .ss-gridfield-item:hover {
   background: white;
 }

--- a/scss/UserForm_cms.scss
+++ b/scss/UserForm_cms.scss
@@ -4,7 +4,8 @@
 
 .cms {
 	.uf-field-editor {
-		
+		padding-bottom: 0;
+
 		// Row styles
 		table.ss-gridfield-table {
 			// Standard rows


### PR DESCRIPTION
Fixes a small styling issue in IE where there's a detached border on the bottom of editor.

Before:

![ie8-border-brfore](https://cloud.githubusercontent.com/assets/878176/9347640/86c689da-4680-11e5-9ee0-26daec5e8743.png)

After:

![ie8-border-after](https://cloud.githubusercontent.com/assets/878176/9347641/8dbdcf00-4680-11e5-9fb2-f3ef8a21a16d.png)
