### PR TITLE
place gridfield buttons in button row

### DIFF
--- a/code/model/UserDefinedForm.php
+++ b/code/model/UserDefinedForm.php
@@ -174,8 +174,9 @@ SQL;
 			$config->addComponent(new GridFieldPageCount('toolbar-header-right'));
 			$config->addComponent($pagination = new GridFieldPaginator(25));
 			$config->addComponent(new GridFieldDetailForm());
-			$config->addComponent($export = new GridFieldExportButton());
-			$config->addComponent($print = new GridFieldPrintButton());
+			$config->addComponent(new GridFieldButtonRow('after'));
+			$config->addComponent($export = new GridFieldExportButton('buttons-after-left'));
+			$config->addComponent($print = new GridFieldPrintButton('buttons-after-left'));
 			
 			/**
 			 * Support for {@link https://github.com/colymba/GridFieldBulkEditingTools}


### PR DESCRIPTION
This is so the buttons can inherit the button-row css and have correct spacing
Before 
![image](https://cloud.githubusercontent.com/assets/10215604/9399585/b4736e62-480a-11e5-80ab-9710edb9db54.png)
After 
![image](https://cloud.githubusercontent.com/assets/10215604/9399589/be046cce-480a-11e5-8cb5-7b1e252de3d9.png)
