### PR TITLE
Remove keyup action

### DIFF
--- a/code/model/UserDefinedForm.php
+++ b/code/model/UserDefinedForm.php
@@ -706,11 +706,7 @@ class UserDefinedForm_Controller extends Page_Controller {
 							// what action do we need to keep track of. Something nicer here maybe?
 							// @todo encapulsation
 							$action = "change";
-							
-							if($formFieldWatch->ClassName == "EditableTextField") {
-								$action = "keyup";
-							}
-							
+
 							// is this field a special option field
 							$checkboxField = false;
 							$radioField = false;


### PR DESCRIPTION
Fixes issue #313 by removing the keyup action, the change action becomes the default action. This prevents conditional generated logic being generated with keyup events for radio fields that are relocated in the form field list order. Only change events are required for all form field types.