### PR TITLE
API Disallow HTML uploads by default, make extensions configurable

### DIFF
--- a/code/model/editableformfields/EditableFileField.php
+++ b/code/model/editableformfields/EditableFileField.php
@@ -17,6 +17,15 @@ class EditableFileField extends EditableFormField {
 	);
 
 	/**
+	 * Further limit uploadable file extensions in addition to the restrictions
+	 * imposed by the File.allowed_extensions global configuration.
+	 * @config
+	 */
+	private static $allowed_extensions_blacklist = array(
+		'htm', 'html', 'xhtml', 'swf', 'xml'
+	);
+
+	/**
 	 * @return FieldList
 	 */
 	public function getCMSFields() {
@@ -44,9 +53,12 @@ class EditableFileField extends EditableFormField {
 			->setFieldHolderTemplate('UserFormsField_holder')
 			->setTemplate('UserFormsFileField');
 
-		// filter out '' since this would be a regex problem on JS end
 		$field->getValidator()->setAllowedExtensions(
-			array_filter(Config::inst()->get('File', 'allowed_extensions'))
+			array_diff(
+				// filter out '' since this would be a regex problem on JS end
+				array_filter(Config::inst()->get('File', 'allowed_extensions')),
+				$this->config()->allowed_extensions_blacklist
+			)
 		);
 
 		$folder = $this->Folder();

--- a/docs/en/installation.md
+++ b/docs/en/installation.md
@@ -29,6 +29,9 @@ to any configured recipients.
 
 Allowed file extensions can be configured globally through `File.allowed_extensions`,
 and default to a safe set of files (e.g. disallowing `*.php` uploads).
+You can define further exclusions through the `EditableFileField.allowed_extensions_blacklist`
+configuration setting.
+
 The allowed upload size is determined by PHP configuration
 for this website (the smaller value of `upload_max_filesize` or `post_max_size`).
 

--- a/tests/EditableFormFieldTest.php
+++ b/tests/EditableFormFieldTest.php
@@ -102,4 +102,12 @@ class EditableFormFieldTest extends FunctionalTest {
 		$this->assertNotContains('notallowedextension', $formField->getValidator()->getAllowedExtensions());
 	}
 
+	public function testFileFieldAllowedExtensionsBlacklist() {
+		Config::inst()->update('EditableFileField', 'allowed_extensions_blacklist', array('jpg'));
+		$fileField = $this->objFromFixture('EditableFileField', 'file-field');
+		$formField = $fileField->getFormField();
+
+		$this->assertNotContains('jpg', $formField->getValidator()->getAllowedExtensions());
+	}
+
 }


### PR DESCRIPTION
HTML uploads are only relevant for SilverStripe 3.1,
since they're disallowed by default from 3.2 onwards in
the File.allowed_extensions configuration already.