### PR TITLE
API Hide EditableFileField by default

### DIFF
--- a/code/model/editableformfields/EditableFileField.php
+++ b/code/model/editableformfields/EditableFileField.php
@@ -17,6 +17,13 @@ class EditableFileField extends EditableFormField {
 	);
 
 	/**
+	 * Disable file upload fields by default since every implementation
+	 * needs to first consider how to secure files uploaded in the webroot.
+	 * Please check the installation documenation for more details.
+	 */
+	private static $hidden = true;
+
+	/**
 	 * @return FieldList
 	 */
 	public function getCMSFields() {

--- a/docs/en/installation.md
+++ b/docs/en/installation.md
@@ -21,26 +21,34 @@ You should see a new PageType in the CMS 'User Defined Form'. This has a new 'Fo
 
 ## File Uploads and Security
 
-The module allows adding a "File Upload Field" to a form,
-which enables users of this form to upload files to the website's assets
+The module optionally allows adding a "File Upload Field" to a form.
+The field enables users of this form to upload files to the website's assets
 so they can be viewed later by CMS authors. Small files
 are also attached to the (optional) email notifications
 to any configured recipients.
 
-Allowed file extensions can be configured globally through `File.allowed_extensions`,
-and default to a safe set of files (e.g. disallowing `*.php` uploads).
-The allowed upload size is determined by PHP configuration
-for this website (the smaller value of `upload_max_filesize` or `post_max_size`).
-
+The field is disabled by default since implementors need to determine how files are secured.
 Since uploaded files are kept in `assets/` folder of the webroot, there is no built-in
 permission control around who can view them. It is unlikely
 that website users guess the URLs to uploaded files unless
 they are specifically exposed through custom code.
 
-Nevertheless, you should think carefully about the use case for file uploads.
+You should think carefully about the use case for file uploads.
 Unauthorised viewing of files might be desired, e.g. submissions for public competitions. 
 In other cases, submissions could be expected to contain private data.
 Please consider securing these files, e.g. through the [secureassets](http://addons.silverstripe.org/add-ons/silverstripe/secureassets) module.
+
+The field can be enabled with the following configuration setting:
+
+```yml
+EditableFileField:
+  hidden: false
+```
+
+Allowed file extensions can be configured globally through `File.allowed_extensions`,
+and default to a safe set of files (e.g. disallowing `*.php` uploads).
+The allowed upload size is determined by PHP configuration
+for this website (the smaller value of `upload_max_filesize` or `post_max_size`).
 
 ### Custom email templates
 

--- a/docs/en/user-documentation.md
+++ b/docs/en/user-documentation.md
@@ -106,6 +106,8 @@ automatically when a form is filled out.
 
 Selecting a File Upload Field adds a field where users can upload a file from their
 computers. This is useful for getting documents and media files.
+This field is disabled by default. Please talk to your CMS administrator for details
+if the functionality is not available in your CMS installation.
 
 The folder that this field uploads to can be customised by selecting "Show Options"
 and then selecting a new folder from the "Select upload folder" option. If no folder


### PR DESCRIPTION
This forces implementors to think about the implications
of enabling it - usually the upload folder needs to be
secured in some fashion, e.g. through the secureassets module.