### PR TITLE
ENHANCEMENT: Add 'HideLabel' field for EditableLiteralField objects

### DIFF
--- a/code/model/editableformfields/EditableLiteralField.php
+++ b/code/model/editableformfields/EditableLiteralField.php
@@ -31,7 +31,8 @@ class EditableLiteralField extends EditableFormField {
 
 	private static $db = array(
 		'Content' => 'HTMLText', // From CustomSettings
-		'HideFromReports' => 'Boolean(0)' // from CustomSettings
+		'HideFromReports' => 'Boolean(0)', // from CustomSettings
+		'HideLabel' => 'Boolean(0)'
 	);
 
 	private static $defaults = array(
@@ -103,6 +104,10 @@ class EditableLiteralField extends EditableFormField {
 			CheckboxField::create(
 				'HideFromReports',
 				_t('EditableLiteralField.HIDEFROMREPORT', 'Hide from reports?')
+			),
+			CheckboxField::create(
+				'HideLabel',
+				_t('EditableLiteralField.HIDELABEL', "Hide 'Title' label on frontend?")
 			)
 		));
 
@@ -113,7 +118,7 @@ class EditableLiteralField extends EditableFormField {
 		// Build label and css classes
 		$label = '';
 		$classes = $this->ExtraClass;
-		if(empty($this->Title)) {
+		if(empty($this->Title) || $this->HideLabel) {
 			$classes .= " nolabel";
 		} else {
 			$label = "<label class='left'>{$this->EscapedTitle}</label>";

--- a/docs/en/user-documentation.md
+++ b/docs/en/user-documentation.md
@@ -132,6 +132,10 @@ You can edit the HTML blog from the "Show options" link.
 If you do not check the "Hide from reports" checkbox then this field will be displayed
 in submission reports.
 
+If you check the "Hide 'Title' label on frontend" checkbox then the title of this field
+will be hidden on the form. This is useful when you want to output specific HTML code and
+add your own headings within the content of this field.
+
 Note: Take care not to allow input from unauthorised sources or users, as custom script
 or code could be injected into your form.
 

--- a/tests/EditableLiteralFieldTest.php
+++ b/tests/EditableLiteralFieldTest.php
@@ -35,4 +35,15 @@ class EditableLiteralFieldTest extends SapphireTest {
 		$field->setContent($rawContent);
 		$this->assertEquals($rawContent, $field->getContent());
 	}
+
+	public function testHideLabel() {
+		$field = new EditableLiteralField(array(
+			'Title' => 'Test label'
+		));
+
+		$this->assertContains('Test label', $field->getFormField()->Field());
+
+		$field->HideLabel = true;
+		$this->assertNotContains('Test label', $field->getFormField()->Field());
+	}
 }


### PR DESCRIPTION
This adds a hide label field so that literal fields don't need to include a label on the left.

It currently only changes EditableLiteralField because labels should always exist for other form field types, but literal fields don't contain any user-editable content fields, so a `<label>` element is irrelevant.

![hide-labelfield](https://cloud.githubusercontent.com/assets/893117/10125495/4457f6a2-65d3-11e5-8f99-2b30d8969784.png)
