### PR TITLE
Make EmailBody HTMLText

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,8 @@ language: php
 php: 
  - 5.3
 
+sudo: false
+
 env:
  - DB=MYSQL CORE_RELEASE=3.1
  - DB=MYSQL CORE_RELEASE=3

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,25 +1,25 @@
 # See https://github.com/silverstripe-labs/silverstripe-travis-support for setup details
 
-language: php 
-php: 
- - 5.3
+language: php
+php:
+  - 5.3
 
 sudo: false
 
 env:
- - DB=MYSQL CORE_RELEASE=3.1
- - DB=MYSQL CORE_RELEASE=3
- - DB=PGSQL CORE_RELEASE=3.1
+  - DB=MYSQL CORE_RELEASE=3.1
+  - DB=MYSQL CORE_RELEASE=3
+  - DB=PGSQL CORE_RELEASE=3.1
 
 matrix:
   include:
     - php: 5.4
-      env: DB=MYSQL CORE_RELEASE=master
+      env: DB=MYSQL CORE_RELEASE=3.2
 
 before_script:
- - git clone git://github.com/silverstripe-labs/silverstripe-travis-support.git ~/travis-support
- - php ~/travis-support/travis_setup.php --source `pwd` --target ~/builds/ss
- - cd ~/builds/ss
+  - git clone git://github.com/silverstripe-labs/silverstripe-travis-support.git ~/travis-support
+  - php ~/travis-support/travis_setup.php --source `pwd` --target ~/builds/ss
+  - cd ~/builds/ss
 
-script: 
- - phpunit userforms/tests/
+script:
+  - vendor/bin/phpunit userforms/tests/

--- a/code/model/formfields/EditableLiteralField.php
+++ b/code/model/formfields/EditableLiteralField.php
@@ -72,7 +72,7 @@ class EditableLiteralField extends EditableFormField {
 	}
 	
 	public function getFieldConfiguration() {
-		$textAreaField = new TextareaField(
+		$textAreaField = new HTMLEditorField(
 			$this->getSettingName('Content'),
 			"HTML",
 			$this->getContent()

--- a/css/FieldEditor.css
+++ b/css/FieldEditor.css
@@ -67,9 +67,9 @@ li.class-UserDefinedForm > a .jstree-pageicon { background-position: 0 -64px; }
 		overflow: hidden;
 	}
 		.FieldEditor .FieldList .EditableFormField * {
-			display: inline;
 			vertical-align: middle;
 		}
+
 		.FieldEditor .FieldList .EditableFormField .fieldHandler,
 		.FieldEditor .FieldList .EditableFormField .handle {
 			cursor: move;
@@ -112,10 +112,6 @@ li.class-UserDefinedForm > a .jstree-pageicon { background-position: 0 -64px; }
 			padding: 3px;
 			clear: both;			
 		}
-			.FieldEditor .FieldList .EditableFormField .extraOptions * {
-				display: block;
-			}
-			
 				.FieldEditor .FieldList .EditableFormField .extraOptions .handle {
 					float: left;
 					margin-right: 3px;


### PR DESCRIPTION
I was struggling with linebreaks in the EmailBody. They were totally ignored even if "send plaint text" was not enabled. I finally ended up modifying you Code.
I am currently using 2.0.9 with SS3.1 as I couldn't save UserForm-pages with the latest version, even on clean install. So possibly this request is already obsolete.

Here are the changes I made which worked perfectly and allow for so much more readable Emails:

UserDefinedForms.php

line 1152
'EmailBody' => 'HTMLText',

line 1185
new HTMLEditorField('EmailBody', _t('UserDefinedForm.EMAILBODY','Body'))