### PR TITLE
Remove '[' and ']' from jQuery selector for checkbox groups

### DIFF
--- a/javascript/UserForm.js
+++ b/javascript/UserForm.js
@@ -125,7 +125,7 @@ jQuery(function ($) {
 		// When a field becomes valid.
 		success: function (error) {
 			var errorId = $(error).attr('id'),
-				fieldId = errorId.substr(0, errorId.indexOf('-error')),
+				fieldId = errorId.substr(0, errorId.indexOf('-error')).replace(/[\\[\\]]/, ''),
 				isCheckboxGroup = $(error).closest('.requiredField').hasClass('checkboxset');
 
 			// We need to escapse the field id if it's a checkboxfield

--- a/javascript/UserForm.js
+++ b/javascript/UserForm.js
@@ -125,15 +125,11 @@ jQuery(function ($) {
 		// When a field becomes valid.
 		success: function (error) {
 			var errorId = $(error).attr('id'),
-				fieldId = errorId.substr(0, errorId.indexOf('-error')).replace(/[\\[\\]]/, ''),
-				isCheckboxGroup = $(error).closest('.requiredField').hasClass('checkboxset');
+				fieldId = errorId.substr(0, errorId.indexOf('-error')).replace(/[\\[\\]]/, '');
 
-			// We need to escapse the field id if it's a checkboxfield
-			// because jQuery breaks when using selector that end with
+			// Remove square brackets since jQuery.validate.js uses idOrName,
+			// which breaks further on when using a selector that end with
 			// square brackets.
-			if (isCheckboxGroup) {
-				fieldId = fieldId.replace('[]', '\\\\[\\\\]');
-			}
 
 			error.remove();
 


### PR DESCRIPTION
sizzle errors when id given contains [ or ] like UserForm_Form_EditableCheckboxGroupField1138[]