### PR TITLE
MINOR: New email object for each recipient

### DIFF
--- a/code/model/UserDefinedForm.php
+++ b/code/model/UserDefinedForm.php
@@ -662,22 +662,23 @@ JS
 
 		// email users on submit.
 		if($recipients = $this->FilteredEmailRecipients($data, $form)) {
-			$email = new UserFormRecipientEmail($submittedFields);
-			$mergeFields = $this->getMergeFieldsMap($emailData['Fields']);
-
-			if($attachments) {
-				foreach($attachments as $file) {
-					if($file->ID != 0) {
-						$email->attachFile(
-							$file->Filename,
-							$file->Filename,
-							HTTP::get_mime_type($file->Filename)
-						);
-					}
-				}
-			}
 
 			foreach($recipients as $recipient) {
+				$email = new UserFormRecipientEmail($submittedFields);
+				$mergeFields = $this->getMergeFieldsMap($emailData['Fields']);
+	
+				if($attachments) {
+					foreach($attachments as $file) {
+						if($file->ID != 0) {
+							$email->attachFile(
+								$file->Filename,
+								$file->Filename,
+								HTTP::get_mime_type($file->Filename)
+							);
+						}
+					}
+				}
+				
 				$parsedBody = SSViewer::execute_string($recipient->getEmailBodyContent(), $mergeFields);
 
 				if (!$recipient->SendPlain && $recipient->emailTemplateExists()) {


### PR DESCRIPTION
Creating a new email object for each recipient so that no state from the previous email object is carried through. Fixes silverstripe/silverstripe-userforms#356.