### PR TITLE
MINOR: Styling for one or more buttons without the list styling

### DIFF
--- a/templates/Includes/UserFormActionNav.ss
+++ b/templates/Includes/UserFormActionNav.ss
@@ -1,0 +1,7 @@
+<% if $Actions %>
+<nav class="Actions">
+	<% loop $Actions %>
+		$Field
+	<% end_loop %>
+</nav>
+<% end_if %>

--- a/templates/Includes/UserFormStepNav.ss
+++ b/templates/Includes/UserFormStepNav.ss
@@ -1,7 +1,5 @@
 <nav id="step-navigation" class="step-navigation">
 	<ul class="step-buttons">
-
-		<% if $Steps.Count > 1 %>
 		<%--
 			If JavaScript is disabled multi-step forms are displayed as a single page
 			so the 'prev' and 'next' button are not used. These buttons are made visible via JavaScript.
@@ -12,7 +10,6 @@
 		<li class="step-button-wrapper" aria-hidden="true" style="display:none;">
 			<button class="step-button-next">Next</button>
 		</li>
-		<% end_if %>
 
 		<% if $Actions %>
 		<li class="step-button-wrapper Actions">

--- a/templates/UserForm.ss
+++ b/templates/UserForm.ss
@@ -17,6 +17,10 @@
 	<div class="clear"><!-- --></div>
 </fieldset>
 
-<% include UserFormStepNav %>
+<% if $Steps.Count > 1 %>
+	<% include UserFormStepNav %>
+<% else %>
+	<% include UserFormActionNav %>
+<% end_if %>
 
 </form>


### PR DESCRIPTION
Issue found: if there is only one button added then the step-buttons styling and list structure is added by default which is unnecessary.

Fix: If there are more then 1 steps then show the UserFormStepNav.ss template, otherwise show the UserFormActionNav.ss which just shows the nav and the action button (or buttons).