### PR TITLE
Add placeholder to Numeric and Email fields

### DIFF
--- a/code/model/editableformfields/EditableEmailField.php
+++ b/code/model/editableformfields/EditableEmailField.php
@@ -13,6 +13,24 @@ class EditableEmailField extends EditableFormField {
 
 	private static $plural_name = 'Email Fields';
 
+	private static $db = array(
+		'Placeholder' => 'Varchar(255)'
+	);
+
+	public function getCMSFields() {
+		$this->beforeUpdateCMSFields(function($fields) {
+			$fields->addFieldToTab(
+				'Root.Main',
+				TextField::create(
+					'Placeholder',
+					_t('EditableTextField.PLACEHOLDER', 'Placeholder')
+				)
+			);
+		});
+
+		return parent::getCMSFields();
+	}
+
 	public function getSetsOwnError() {
 		return true;
 	}
@@ -36,5 +54,9 @@ class EditableEmailField extends EditableFormField {
 		parent::updateFormField($field);
 
 		$field->setAttribute('data-rule-email', true);
+
+		if($this->Placeholder) {
+			$field->setAttribute('placeholder', $this->Placeholder);
+		}
 	}
 }

--- a/code/model/editableformfields/EditableNumericField.php
+++ b/code/model/editableformfields/EditableNumericField.php
@@ -15,11 +15,26 @@ class EditableNumericField extends EditableFormField {
 
 	private static $db = array(
 		'MinValue' => 'Int',
-		'MaxValue' => 'Int'
+		'MaxValue' => 'Int',
+		'Placeholder' => 'Varchar(255)'
 	);
 
 	public function getSetsOwnError() {
 		return true;
+	}
+
+	public function getCMSFields() {
+		$this->beforeUpdateCMSFields(function($fields) {
+			$fields->addFieldToTab(
+				'Root.Main',
+				TextField::create(
+					'Placeholder',
+					_t('EditableTextField.PLACEHOLDER', 'Placeholder')
+				)
+			);
+		});
+
+		return parent::getCMSFields();
 	}
 
 	/**
@@ -63,6 +78,10 @@ class EditableNumericField extends EditableFormField {
 
 		if($this->MaxValue) {
 			$field->setAttribute('data-rule-max', $this->MaxValue);
+		}
+
+		if($this->Placeholder) {
+			$field->setAttribute('placeholder', $this->Placeholder);
 		}
 	}
 }


### PR DESCRIPTION
Fixes https://github.com/silverstripe/silverstripe-userforms/issues/366

Before:
![before-default](https://cloud.githubusercontent.com/assets/878176/11733890/1a38a384-a017-11e5-9d3f-5693716b54f6.png)

After:
![after-default](https://cloud.githubusercontent.com/assets/878176/11733897/2fb25354-a017-11e5-9506-bc1d01505ccd.png)

Email field:
![after-email](https://cloud.githubusercontent.com/assets/878176/11733917/689dc9fa-a017-11e5-8064-035098352502.png)

Numeric field:
![after-numeric](https://cloud.githubusercontent.com/assets/878176/11733918/71bc9296-a017-11e5-857f-0d3d75995d0a.png)


