### PR TITLE
API Use core validation for form submission

### DIFF
--- a/code/extensions/UserFormValidator.php
+++ b/code/extensions/UserFormValidator.php
@@ -22,7 +22,7 @@ class UserFormValidator extends RequiredFields {
 				// Page at top level, or after another page is ok
 				if(empty($stack) || (count($stack) === 1 && $stack[0] instanceof EditableFormStep)) {
 					$stack = array($field);
-					$conditionalStep = $field->DisplayRules()->count() > 0;
+					$conditionalStep = $field->EffectiveDisplayRules()->count() > 0;
 					continue;
 				}
 

--- a/code/model/UserDefinedForm.php
+++ b/code/model/UserDefinedForm.php
@@ -426,7 +426,7 @@ class UserDefinedForm_Controller extends Page_Controller {
 				}
 
 				// Check for field dependencies / default
-				foreach($field->DisplayRules() as $rule) {
+				foreach($field->EffectiveDisplayRules() as $rule) {
 
 					// Get the field which is effected
 					$formFieldWatch = EditableFormField::get()->byId($rule->ConditionFieldID);

--- a/composer.json
+++ b/composer.json
@@ -38,7 +38,7 @@
 	},
 	"extra": {
 		"branch-alias": {
-			"dev-master": "3.1.x-dev"
+			"dev-master": "4.0.x-dev"
 		}
 	}
 }

--- a/tests/EditableFormFieldTest.php
+++ b/tests/EditableFormFieldTest.php
@@ -55,7 +55,8 @@ class EditableFormFieldTest extends FunctionalTest {
 
 		// form has 2 fields - a checkbox and a text field
 		// it has 1 rule - when ticked the checkbox hides the text field
-		$this->assertEquals($rules->Count(), 1);
+		$this->assertEquals(1, $rules->Count());
+		$this->assertEquals($rules, $checkbox->EffectiveDisplayRules());
 
 		$checkboxRule = $rules->First();
 		$checkboxRule->ConditionFieldID = $field->ID;
@@ -63,6 +64,10 @@ class EditableFormFieldTest extends FunctionalTest {
 		$this->assertEquals($checkboxRule->Display, 'Hide');
 		$this->assertEquals($checkboxRule->ConditionOption, 'HasValue');
 		$this->assertEquals($checkboxRule->FieldValue, '6');
+
+		// If field is required then all custom rules are disabled
+		$checkbox->Required = true;
+		$this->assertEquals(0, $checkbox->EffectiveDisplayRules()->count());
 	}
 
 	function testEditableDropdownField() {

--- a/tests/EditableLiteralFieldTest.php
+++ b/tests/EditableLiteralFieldTest.php
@@ -7,14 +7,7 @@ class EditableLiteralFieldTest extends SapphireTest {
 
 	public function setUp() {
 		parent::setUp();
-		Config::nest();
 		HtmlEditorConfig::set_active('cms');
-	}
-
-
-	public function tearDown() {
-		Config::unnest();
-		parent::tearDown();
 	}
 
 	/**

--- a/tests/UserDefinedFormTest.yml
+++ b/tests/UserDefinedFormTest.yml
@@ -100,7 +100,13 @@ EditableTextField:
     
   some-field:
     Name: SomeField
-    
+
+  another-required:
+    Name: required-text
+    Title: Required Text Field
+    Required: true
+    CustomErrorMessage: 'This field is required'
+
 EditableDropdown:
   basic-dropdown:
     Name: basic-dropdown
@@ -136,6 +142,11 @@ EditableEmailField:
   email-field:
     Name: email-field
     Title: Email
+
+  another-email-field:
+    Name: required-email
+    Title: Enter your email
+    CustomErrorMessage: 'That email is not valid'
 
 EditableRadioField:
   radio-field:
@@ -251,3 +262,7 @@ UserDefinedForm:
   empty-page:
     Title: 'Page with empty step'
     Fields: =>EditableFormStep.form6step1, =>EditableTextField.field-1, =>EditableFormStep.form6step2, =>EditableTextField.field-2, =>EditableFormStep.form6step3
+
+  email-form:
+    Title: 'Page with email field'
+    Fields: =>EditableEmailField.another-email-field, =>EditableTextField.another-required


### PR DESCRIPTION
Fixes #350, #404, and #357
This change abandons validation via EditableFormField::validateField, as it bypassed too many core validation mechanisms (RequiredFields, etc).
In order to enforce consistency of editable field validation, display rules have been hard-disabled when a field is marked as required.
Since this removes functionality, I have incremented the major version number