### PR TITLE
issue-351, run-time error 'log' function doesn't exist on UserFormsUpgradeTask class

### DIFF
--- a/code/tasks/UserFormsUpgradeService.php
+++ b/code/tasks/UserFormsUpgradeService.php
@@ -189,7 +189,7 @@ class UserFormsUpgradeService {
 		return $rule;
 	}
 
-	protected function log($message) {
+	public function log($message) {
 		if($this->getQuiet()) {
 			return;
 		}

--- a/code/tasks/UserFormsUpgradeTask.php
+++ b/code/tasks/UserFormsUpgradeTask.php
@@ -12,11 +12,10 @@ class UserFormsUpgradeTask extends BuildTask {
 	protected $description = "Upgrade tool for sites upgrading to userforms 3.0";
 
 	public function run($request) {
-		$this->log("Upgrading userforms module");
-		Injector::inst()
-			->create('UserFormsUpgradeService')
-			->setQuiet(false)
+		$service = Injector::inst()->create('UserFormsUpgradeService');
+		$service->log("Upgrading userforms module");
+		$service->setQuiet(false)
 			->run();
-		$this->log("Done");
+		$service->log("Done");
 	}
 }


### PR DESCRIPTION
BUG call log() function on instance of UserFormsUpgradeService, to remove  run time error that says 'log' function doesn't exist on UserFormsUpgradeTask class