### PR TITLE
fixes late extensions binding

### DIFF
--- a/code/forms/UserForm.php
+++ b/code/forms/UserForm.php
@@ -17,10 +17,13 @@ class UserForm extends Form {
 		parent::__construct(
 			$controller,
 			$name,
-			$this->getFormFields(),
-			$this->getFormActions(),
-			$this->getRequiredFields()
+			new FieldList(),
+			new FieldList()
 		);
+
+		$this->setFields($this->getFormFields());
+		$this->setActions($this->getFormActions());
+		$this->setValidator($this->getRequiredFields());
 
 		// Number each page
 		$stepNumber = 1;


### PR DESCRIPTION
Construct adds extensions, so calling functions which have extend calls in them before the parent:constructor means the extend calls will never find any extensions.