### PR TITLE
Change CSV field export order to match form order - Fix #438

### DIFF
--- a/code/model/UserDefinedForm.php
+++ b/code/model/UserDefinedForm.php
@@ -165,11 +165,12 @@ class UserDefinedForm extends Page {
 
 			// get a list of all field names and values used for print and export CSV views of the GridField below.
 			$columnSQL = <<<SQL
-SELECT "Name", "Title"
+SELECT "SubmittedFormField"."Name" as "Name", "SubmittedFormField"."Title" as "Title", IFNULL("EditableFormField"."Sort", 999) AS "Sort"
 FROM "SubmittedFormField"
 LEFT JOIN "SubmittedForm" ON "SubmittedForm"."ID" = "SubmittedFormField"."ParentID"
+LEFT JOIN "EditableFormField" ON "EditableFormField"."Title" = "SubmittedFormField"."Title" AND "EditableFormField"."ParentID" = '$parentID'
 WHERE "SubmittedForm"."ParentID" = '$parentID'
-ORDER BY "Title" ASC
+ORDER BY "Sort", "Title"
 SQL;
 			// Sanitise periods in title
 			$columns = array();


### PR DESCRIPTION
It will order the CSV field export to match the current order of the field. Previously, it would be sorted alphabetically.
For any fields that are not in the current form, they'll be at the end of the CSV, sorted by Title again.