### PR TITLE
By default, new form fields should be visible

### DIFF
--- a/code/model/editableformfields/EditableFormField.php
+++ b/code/model/editableformfields/EditableFormField.php
@@ -81,6 +81,11 @@ class EditableFormField extends DataObject {
 		"RightTitle" => "Varchar(255)", // from CustomSettings
 		"ShowOnLoad" => "Boolean(1)", // from CustomSettings
 	);
+	
+	private static $defaults = array(
+    	'ShowOnLoad' => true,
+    );
+
 
 	/**
 	 * @config

--- a/code/model/editableformfields/EditableFormField.php
+++ b/code/model/editableformfields/EditableFormField.php
@@ -83,8 +83,8 @@ class EditableFormField extends DataObject {
 	);
 	
 	private static $defaults = array(
-    	'ShowOnLoad' => true,
-    );
+		'ShowOnLoad' => true,
+	);
 
 
 	/**


### PR DESCRIPTION
Having to click through 2 levels of property settings to make a new form field visible seems a bit much ... or else I have not found the configuration setting for this.