### PR TITLE
Update EditableFormField.php

### DIFF
--- a/code/model/editableformfields/EditableFormField.php
+++ b/code/model/editableformfields/EditableFormField.php
@@ -760,7 +760,7 @@ class EditableFormField extends DataObject {
 	 * @return Varchar
 	 */
 	public function getErrorMessage() {
-		$title = strip_tags("'". ($this->Title ? $this->Title : $this->Name) . "'");
+		$title = strip_tags($this->Title ? $this->Title : $this->Name);
 		$standard = sprintf(_t('Form.FIELDISREQUIRED', '%s is required').'.', $title);
 
 		// only use CustomErrorMessage if it has a non empty value


### PR DESCRIPTION
Default required error messages are not decoded properly because of the single quotes around the field name. My message ends up displaying as "&amp;#039;My field&amp;#039; is required." There may be a more elegant way of doing this, but removing the quotes is a quick fix.