### PR TITLE
BUG Fix issue with maxlength="0"

### DIFF
--- a/code/model/editableformfields/EditableTextField.php
+++ b/code/model/editableformfields/EditableTextField.php
@@ -79,7 +79,7 @@ class EditableTextField extends EditableFormField {
 				->setTemplate('UserFormsTextareaField')
 				->setRows($this->Rows);
 		} else {
-			$field = TextField::create($this->Name, $this->EscapedTitle, $this->Default, $this->MaxLength)
+			$field = TextField::create($this->Name, $this->EscapedTitle, $this->Default)
 				->setFieldHolderTemplate('UserFormsField_holder')
 				->setTemplate('UserFormsField');
 		}
@@ -97,12 +97,15 @@ class EditableTextField extends EditableFormField {
 	protected function updateFormField($field) {
 		parent::updateFormField($field);
 
-		if($this->MinLength) {
-			$field->setAttribute('data-rule-minlength', $this->MinLength);
+		if(is_numeric($this->MinLength) && $this->MinLength > 0) {
+			$field->setAttribute('data-rule-minlength', intval($this->MinLength));
 		}
 
-		if($this->MaxLength) {
-			$field->setAttribute('data-rule-maxlength', $this->MaxLength);
+		if(is_numeric($this->MaxLength) && $this->MaxLength > 0) {
+            if($field instanceof TextField) {
+                $field->setMaxLength(intval($this->MaxLength));
+            }
+			$field->setAttribute('data-rule-maxlength', intval($this->MaxLength));
 		}
 
 		if($this->Placeholder) {

--- a/tests/EditableFormFieldTest.php
+++ b/tests/EditableFormFieldTest.php
@@ -144,4 +144,35 @@ class EditableFormFieldTest extends FunctionalTest {
 		$this->assertNotEquals($textfield1->Name, $textfield2->Name);
 	}
 
+    public function testLengthRange() {
+        /** @var EditableTextField $textField */
+        $textField = $this->objFromFixture('EditableTextField', 'basic-text');
+
+        // Empty range
+        /** @var TextField $formField */
+        $textField->MinLength = 0;
+        $textField->MaxLength = 0;
+        $attributes = $textField->getFormField()->getAttributes();
+        $this->assertFalse(isset($attributes['maxLength']));
+        $this->assertFalse(isset($attributes['data-rule-minlength']));
+        $this->assertFalse(isset($attributes['data-rule-maxlength']));
+
+        // Test valid range
+        $textField->MinLength = 10;
+        $textField->MaxLength = 20;
+        $attributes = $textField->getFormField()->getAttributes();
+        $this->assertEquals(20, $attributes['maxLength']);
+        $this->assertEquals(20, $attributes['size']);
+        $this->assertEquals(10, $attributes['data-rule-minlength']);
+        $this->assertEquals(20, $attributes['data-rule-maxlength']);
+
+        // textarea
+        $textField->Rows = 3;
+        $attributes = $textField->getFormField()->getAttributes();
+        $this->assertFalse(isset($attributes['maxLength']));
+        $this->assertEquals(10, $attributes['data-rule-minlength']);
+        $this->assertEquals(20, $attributes['data-rule-maxlength']);
+    }
+
+
 }


### PR DESCRIPTION
Fixes #367 

I had a LOT of trouble trying to reproduce #367.... in the end I wasn't able to, so I cleaned up the logic and made the type checking a lot more strict, and use an explicit numeric comparison rather than falsey.

Include test for various numeric ranges, as well as multi-line textarea.