### PR TITLE
Set EditableCustomRule.FieldValue to Varchar(255)

### DIFF
--- a/code/model/EditableCustomRule.php
+++ b/code/model/EditableCustomRule.php
@@ -23,7 +23,7 @@ class EditableCustomRule extends DataObject {
 	private static $db = array(
 		'Display' => 'Enum("Show,Hide")',
 		'ConditionOption' => 'Enum("IsBlank,IsNotBlank,HasValue,ValueNot,ValueLessThan,ValueLessThanEqual,ValueGreaterThan,ValueGreaterThanEqual")',
-		'FieldValue' => 'Varchar'
+		'FieldValue' => 'Varchar(255)'
 	);
 
 	private static $has_one = array(


### PR DESCRIPTION
Fixes issue #477; without explicitly setting the length here, the field defaults to 50, making it impossible to match HasValue on fields with a larger value than that.  255 is chosen to match the limits on EditableOption.Title