### PR TITLE
BUGFIX no Sort value applie to EditableOption on write

### DIFF
--- a/code/model/editableformfields/EditableOption.php
+++ b/code/model/editableformfields/EditableOption.php
@@ -114,4 +114,15 @@ class EditableOption extends DataObject {
     public function canUnpublish($member = null) {
         return $this->canDelete($member);
     }
+
+    /**
+     *
+     */
+    protected function onBeforeWrite() {
+        if (!$this->Sort) {
+            $this->Sort = EditableOption::get()->max('Sort') + 1;
+        }
+
+        parent::onBeforeWrite();
+    }
 }


### PR DESCRIPTION
fixes #492 

A note for the issue, I don't think dates would be automagically sorted as the options have values supplied by the cms user, so there's not a good way to auto sort but allow manual sort if that makes sense. This should at least apply a value to the `Sort` column allowing the sort in the cms to be applied in the form for `EditableOption` lists.