### PR TITLE
ENHANCEMENT add customisable file upload size limit

### DIFF
--- a/docs/en/installation.md
+++ b/docs/en/installation.md
@@ -33,7 +33,7 @@ and default to a safe set of files (e.g. disallowing `*.php` uploads).
 You can define further exclusions through the `EditableFileField.allowed_extensions_blacklist`
 configuration setting.
 
-The allowed upload size is determined by PHP configuration
+The allowed upload size can be set in the cms as long as it doesn't exceed the PHP configuration
 for this website (the smaller value of `upload_max_filesize` or `post_max_size`).
 
 The field is disabled by default since implementors need to determine how files are secured.

--- a/tests/EditableFileFieldTest.php
+++ b/tests/EditableFileFieldTest.php
@@ -1,0 +1,67 @@
+<?php
+
+/**
+ * @package userforms
+ */
+class EditableFileFieldTest extends SapphireTest
+{
+
+    /**
+     * @var string
+     */
+    public static $fixture_file = 'userforms/tests/EditableFormFieldTest.yml';
+
+    /**
+     * @var
+     */
+    private $php_max_file_size;
+
+    /**
+     * Hold the server default max file size upload limit for later
+     */
+    public function setUp()
+    {
+        parent::setUp();
+
+        $editableFileField = singleton('EditableFileField');
+        $this->php_max_file_size = $editableFileField::get_php_max_file_size();
+
+    }
+
+    /**
+     * Test that the field validator has the server default as the max file size upload
+     */
+    public function testDefaultMaxFileSize()
+    {
+        $fileField = $this->objFromFixture('EditableFileField', 'file-field');
+        $formField = $fileField->getFormField();
+
+        $this->assertEquals($this->php_max_file_size, $formField->getValidator()->getAllowedMaxFileSize());
+    }
+
+    /**
+     * Test that validation prevents the provided upload size limit to be less than or equal to the max php size
+     */
+    public function testValidateFileSizeFieldValue()
+    {
+
+        $fileField = $this->objFromFixture('EditableFileField', 'file-field');
+        $this->setExpectedException('ValidationException');
+        $fileField->MaxFileSizeMB = $this->php_max_file_size * 2;
+        $fileField->write();
+    }
+
+    /**
+     * Test the field validator has the updated allowed max file size
+     */
+    public function testUpdatedMaxFileSize()
+    {
+        $fileField = $this->objFromFixture('EditableFileField', 'file-field');
+        $fileField->MaxFileSizeMB = .25;
+        $fileField->write();
+
+        $formField = $fileField->getFormField();
+        $this->assertEquals($formField->getValidator()->getAllowedMaxFileSize(), 256);
+    }
+
+}


### PR DESCRIPTION
ping #430 

I've done some testing with this and I'm running into some issues around [line 95](https://github.com/muskie9/silverstripe-userforms/blob/enhancement/fileSizeLimit%23430/code/model/editableformfields/EditableFileField.php#L95-L97) where calling `$this->MaxFileSizeMB` is returning `0` even though the value has successfully been saved. I debugged a bit by trying other db fields like `$this->Title` and that data is accessible as expected. Does anyone notice anything glaring that I'm overlooking?