### PR TITLE
Added missing translation for "ERROR_CONTAINER_HEADER"

### DIFF
--- a/javascript/lang/de_DE.js
+++ b/javascript/lang/de_DE.js
@@ -13,6 +13,7 @@ if (typeof(ss) === 'undefined' || typeof(ss.i18n) === 'undefined') {
     "UserForms.ADDING_OPTION": "Füge Option hinzu",
     "UserForms.ADDING_RULE": "Füge Regel hinzu",
     "UserForms.CONFIRM_DELETE_ALL_SUBMISSIONS": "Alle Einsendungen werden dauerhaft gelöscht. Wirklich fortfahren?",
+	"UserForms.ERROR_CONTAINER_HEADER": "Bitte korrigieren Sie die Fehler und senden das Formular erneut:",
     "UserForms.ERROR_CREATING_FIELD": "Fehler beim erstellen des Feldes",
     "UserForms.ERROR_CREATING_OPTION": "Fehler beim erstellen der Option",
     "UserForms.HIDE_OPTIONS": "Optionen verbergen",

--- a/javascript/lang/en.js
+++ b/javascript/lang/en.js
@@ -13,6 +13,7 @@ if (typeof(ss) === 'undefined' || typeof(ss.i18n) === 'undefined') {
     "UserForms.ADDING_OPTION": "Adding option",
     "UserForms.ADDING_RULE": "Adding rule",
     "UserForms.CONFIRM_DELETE_ALL_SUBMISSIONS": "All submissions will be permanently removed. Continue?",
+	"UserForms.ERROR_CONTAINER_HEADER": "Please correct the following errors and try again:",
     "UserForms.ERROR_CREATING_FIELD": "Error creating field",
     "UserForms.ERROR_CREATING_OPTION": "Error creating option",
     "UserForms.HIDE_OPTIONS": "Hide options",

--- a/javascript/lang/en_GB.js
+++ b/javascript/lang/en_GB.js
@@ -13,6 +13,7 @@ if (typeof(ss) === 'undefined' || typeof(ss.i18n) === 'undefined') {
     "UserForms.ADDING_OPTION": "Adding option",
     "UserForms.ADDING_RULE": "Adding rule",
     "UserForms.CONFIRM_DELETE_ALL_SUBMISSIONS": "All submissions will be permanently removed. Continue?",
+	"UserForms.ERROR_CONTAINER_HEADER": "Please correct the following errors and try again:",
     "UserForms.ERROR_CREATING_FIELD": "Error creating field",
     "UserForms.ERROR_CREATING_OPTION": "Error creating option",
     "UserForms.HIDE_OPTIONS": "Hide options",

--- a/javascript/lang/en_US.js
+++ b/javascript/lang/en_US.js
@@ -13,6 +13,7 @@ if (typeof(ss) === 'undefined' || typeof(ss.i18n) === 'undefined') {
     "UserForms.ADDING_OPTION": "Adding option",
     "UserForms.ADDING_RULE": "Adding rule",
     "UserForms.CONFIRM_DELETE_ALL_SUBMISSIONS": "All submissions will be permanently removed. Continue?",
+	"UserForms.ERROR_CONTAINER_HEADER": "Please correct the following errors and try again:",
     "UserForms.ERROR_CREATING_FIELD": "Error creating field",
     "UserForms.ERROR_CREATING_OPTION": "Error creating option",
     "UserForms.HIDE_OPTIONS": "Hide options",


### PR DESCRIPTION
The variable is shown when an javascript validation error occurs and errors are shown above the form, but it was missing in the js translation files.
Added value to english and german translation files.
