### PR TITLE
Enable Shortcode parsing for the Content in EditableLiteralField

### DIFF
--- a/code/model/editableformfields/EditableLiteralField.php
+++ b/code/model/editableformfields/EditableLiteralField.php
@@ -145,7 +145,7 @@ class EditableLiteralField extends EditableFormField
                 Convert::raw2htmlname($this->Name),
                 Convert::raw2att($classes),
                 $label,
-                $this->Content
+                ShortcodeParser::get_active()->parse($this->Content)
             )
         );
 

--- a/code/model/editableformfields/EditableLiteralField.php
+++ b/code/model/editableformfields/EditableLiteralField.php
@@ -145,7 +145,7 @@ class EditableLiteralField extends EditableFormField
                 Convert::raw2htmlname($this->Name),
                 Convert::raw2att($classes),
                 $label,
-                (string)$this->dbObject('Content')
+                $this->dbObject('Content')->forTemplate()
             )
         );
 

--- a/code/model/editableformfields/EditableLiteralField.php
+++ b/code/model/editableformfields/EditableLiteralField.php
@@ -145,7 +145,7 @@ class EditableLiteralField extends EditableFormField
                 Convert::raw2htmlname($this->Name),
                 Convert::raw2att($classes),
                 $label,
-                ShortcodeParser::get_active()->parse($this->Content)
+                $this->dbObject('Content')
             )
         );
 

--- a/code/model/editableformfields/EditableLiteralField.php
+++ b/code/model/editableformfields/EditableLiteralField.php
@@ -145,7 +145,7 @@ class EditableLiteralField extends EditableFormField
                 Convert::raw2htmlname($this->Name),
                 Convert::raw2att($classes),
                 $label,
-                $this->dbObject('Content')
+                (string)$this->dbObject('Content')
             )
         );
 


### PR DESCRIPTION
to be able to use internal links inside the HTMLEditorfield. 
Currently, if you create a link to an internal page inside the the HTMLEditorField it is broken and looks
like this [sitetree_link,id=2]
