### PR TITLE
Added email address validation to model

### DIFF
--- a/code/model/recipients/UserDefinedForm_EmailRecipient.php
+++ b/code/model/recipients/UserDefinedForm_EmailRecipient.php
@@ -442,4 +442,33 @@ class UserDefinedForm_EmailRecipient extends DataObject
 
         return $templates;
     }
+
+    /**
+     * Validate that valid email addresses are being used
+     *
+     * @return ValidationResult
+     */
+    public function validate() {
+        $result = parent::validate();
+        $checkEmail = array(
+            'EmailAddress' => 'EMAILADDRESSINVALID',
+            'EmailFrom' => 'EMAILFROMINVALID',
+            'EmailReplyTo' => 'EMAILREPLYTOINVALID'
+        );
+        foreach ($checkEmail as $check => $translation) {
+		    if ($this->$check) {
+                //may be a comma separated list of emails
+                $addresses = explode(',', $this->$check);
+                foreach ($addresses as $address) {
+                    $trimAddress = trim($address);
+		            if ($address && !Email::is_valid_address($trimAddress)) {
+                        $error = _t("UserDefinedForm_EmailRecipient.$translation",
+                                "Invalid email address $trimAddress");
+                        $result->error($error . " ($trimAddress)");
+                    }
+                }
+            }
+        }
+        return $result;
+    }
 }

--- a/lang/en.yml
+++ b/lang/en.yml
@@ -230,9 +230,9 @@ en:
     EMAILDETAILSTAB: 'Email Details'
     PLURALNAME: 'User Defined Form Email Recipients'
     SINGULARNAME: 'User Defined Form Email Recipient'
-    EMAILADDRESSINVALID: 'Email address has an invalid email address'
-    EMAILFROMINVALID: 'Email from has an invalid email address'
-    EMAILREPLYTOINVALID: 'Email reply has an invalid email address'
+    EMAILADDRESSINVALID: '"EmailAddress" is not valid'
+    EMAILFROMINVALID: '"Email From" is not valid'
+    EMAILREPLYTOINVALID: '"Email Reply To" is not valid'
   UserDefinedForm_EmailRecipientCondition:
     PLURALNAME: 'User Defined Form Email Recipient Conditions'
     SINGULARNAME: 'User Defined Form Email Recipient Condition'

--- a/lang/en.yml
+++ b/lang/en.yml
@@ -230,6 +230,9 @@ en:
     EMAILDETAILSTAB: 'Email Details'
     PLURALNAME: 'User Defined Form Email Recipients'
     SINGULARNAME: 'User Defined Form Email Recipient'
+    EMAILADDRESSINVALID: 'Email address has a invalid email address'
+    EMAILFROMINVALID: 'Email from has a invalid email address'
+    EMAILREPLYTOINVALID: 'Email reply has a invalid email address'
   UserDefinedForm_EmailRecipientCondition:
     PLURALNAME: 'User Defined Form Email Recipient Conditions'
     SINGULARNAME: 'User Defined Form Email Recipient Condition'

--- a/lang/en.yml
+++ b/lang/en.yml
@@ -230,9 +230,9 @@ en:
     EMAILDETAILSTAB: 'Email Details'
     PLURALNAME: 'User Defined Form Email Recipients'
     SINGULARNAME: 'User Defined Form Email Recipient'
-    EMAILADDRESSINVALID: 'Email address has a invalid email address'
-    EMAILFROMINVALID: 'Email from has a invalid email address'
-    EMAILREPLYTOINVALID: 'Email reply has a invalid email address'
+    EMAILADDRESSINVALID: 'Email address has an invalid email address'
+    EMAILFROMINVALID: 'Email from has an invalid email address'
+    EMAILREPLYTOINVALID: 'Email reply has an invalid email address'
   UserDefinedForm_EmailRecipientCondition:
     PLURALNAME: 'User Defined Form Email Recipient Conditions'
     SINGULARNAME: 'User Defined Form Email Recipient Condition'

--- a/tests/UserDefinedFormTest.php
+++ b/tests/UserDefinedFormTest.php
@@ -435,4 +435,24 @@ class UserDefinedFormTest extends FunctionalTest
         $this->assertNotContains('<p></p>', $body);
         $this->assertNotContains('</p><p>Thank you for filling it out</p>', $body);
     }
+
+    public function testEmailAddressValidation()
+    {
+        $this->logInWithPermission('ADMIN');
+
+        // test invalid email addresses fail validation
+        $recipient = $this->objFromFixture('UserDefinedForm_EmailRecipient',
+            'invalid-recipient-list');
+        $result = $recipient->validate();
+        $this->assertFalse($result->valid());
+        $this->assertContains('filtered.example.com', $result->message());
+        $this->assertNotContains('filtered2@example.com', $result->message());
+
+        // test valid email addresses pass validation
+        $recipient = $this->objFromFixture('UserDefinedForm_EmailRecipient',
+            'valid-recipient-list');
+        $result = $recipient->validate();
+        $this->assertTrue($result->valid());
+        $this->assertEmpty($result->message());
+    }
 }

--- a/tests/UserDefinedFormTest.yml
+++ b/tests/UserDefinedFormTest.yml
@@ -227,6 +227,16 @@ UserDefinedForm_EmailRecipient:
     CustomRules: =>UserDefinedForm_EmailRecipientCondition.group-equals-rule, =>UserDefinedForm_EmailRecipientCondition.group-not-equals-rule
     CustomRulesCondition: 'Or'
 
+  valid-recipient-list:
+    EmailAddress: filtered@example.com, filtered2@example.com
+    EmailSubject: Email Subject
+    EmailFrom: no-reply@example.com
+
+  invalid-recipient-list:
+    EmailAddress: filtered.example.com, filtered2@example.com
+    EmailSubject: Email Subject
+    EmailFrom: no-reply@example.com
+
 UserDefinedForm:
   basic-form-page:
     Content: '<p>Here is my form</p><p>$UserDefinedForm</p><p>Thank you for filling it out</p>'


### PR DESCRIPTION
Currently under Recipients on a user form admin page the email addresses are not validated.
This pull request adds validation also takes into account comma separated lists of emails.