### PR TITLE
FIX Travis builds broken with external code coverage

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,8 +23,9 @@ before_script:
 
 script:
   - vendor/bin/phpunit --coverage-clover coverage.clover userforms/tests
+
+after_script:
+  - mv coverage.clover ~/build/$TRAVIS_REPO_SLUG/
+  - cd ~/build/$TRAVIS_REPO_SLUG
   - wget https://scrutinizer-ci.com/ocular.phar
-  - cd ./userforms
-  - git remote rm origin
-  - git remote add origin git@github.com:silverstripe/silverstripe-userforms.git
   - php ocular.phar code-coverage:upload --format=php-clover coverage.clover


### PR DESCRIPTION
* Move to `after_script` which [will not break the build](https://docs.travis-ci.com/user/customizing-the-build#Breaking-the-Build) if it fails
* Remove the git remote commands, move to separate folder instead

Resolves #531 

---

I'd suggest as a follow up to this that we change from Scrutinizer to Codecov.io for code coverage as many of the main SS repos have started to do, and add `COVERAGE=1` to one of the build matrix entries instead of running it on all of them.
