### PR TITLE
FIX Improve publish performance for formfields

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -27,7 +27,9 @@ before_script:
 
 script:
   - vendor/bin/phpunit --coverage-clover coverage.clover userforms/tests
+
+after_script:
+  - mv coverage.clover ~/build/$TRAVIS_REPO_SLUG/
+  - cd ~/build/$TRAVIS_REPO_SLUG
   - wget https://scrutinizer-ci.com/ocular.phar
-  - git remote rm origin
-  - git remote add origin git@github.com:silverstripe/silverstripe-userforms.git
   - php ocular.phar code-coverage:upload --format=php-clover coverage.clover


### PR DESCRIPTION
Fixes #522 

Onpublish, rather than deleting all the fields and then republishing them, this deletes only fields that are no longer associated with the form