### PR TITLE
FIX: jquery validate attempting to validate ul as input

### DIFF
--- a/javascript/UserForm.js
+++ b/javascript/UserForm.js
@@ -77,7 +77,7 @@ jQuery(function ($) {
 	 * Default options for step validation. These get extended in main().
 	 */
 	UserForm.prototype.validationOptions = {
-		ignore: ':hidden',
+		ignore: ':hidden,ul',
 		errorClass: 'error',
 		errorElement: 'span',
 		errorPlacement: function (error, element) {


### PR DESCRIPTION
jQuery validation checks all fields (inputs etc.). For radios it checks the first element with the same name. 

```
		validationTargetFor: function( element ) {

			// If radio/checkbox, validate first element in group instead
			if ( this.checkable( element ) ) {
				element = this.findByName( element.name );
			}

			// Always apply ignore filter
			return $( element ).not( this.settings.ignore )[ 0 ];
		},
```

SS Framework renders a radio group (OptionsetField.php) wrapped in a ul, but also adds the name attribute to this ul. The this.findByName call above then finds the ul, and attempts to treat it like an input, causing an error:

```
jquery.js?m=1462922717:1898 Uncaught TypeError: Cannot read property 'nodeName' of undefined
    at Function.acceptData (jquery.js?m=1462922717:1898)
    at Function.data (jquery.js?m=1462922717:1694)
    at Function.staticRules (jquery.validate.js?m=1485824188:1017)
    at init.rules (jquery.validate.js?m=1485824188:174)
    at $.validator.check (jquery.validate.js?m=1485824188:605)
    at $.validator.checkForm (jquery.validate.js?m=1485824188:404)
    at $.validator.form (jquery.validate.js?m=1485824188:391)
    at HTMLFormElement.<anonymous> (jquery.validate.js?m=1485824188:92)
    at HTMLFormElement.dispatch (jquery.js?m=1462922717:3332)
    at HTMLFormElement.eventHandle (jquery.js?m=1462922717:2941)
```
