### PR TITLE
FIX: Change delete() to deleteFromStage() for EditableMultipleOptionF…

### DIFF
--- a/code/model/editableformfields/EditableMultipleOptionField.php
+++ b/code/model/editableformfields/EditableMultipleOptionField.php
@@ -95,7 +95,7 @@ class EditableMultipleOptionField extends EditableFormField
 
         if ($live) {
             foreach ($live as $option) {
-                $option->delete();
+                $option->deleteFromStage('Live');
             }
         }
 


### PR DESCRIPTION
This is following the 4.2 branch. To replicate, Create a Radio Group and some options. Publish the parent UserForm. The options will be removed from the Draft table, and not recreated.