### PR TITLE
Make getMergeFieldsMap protected

### DIFF
--- a/code/model/UserDefinedForm.php
+++ b/code/model/UserDefinedForm.php
@@ -838,7 +838,7 @@ JS
      * @param ArrayList fields
      * @return ArrayData
      */
-    private function getMergeFieldsMap($fields = array())
+    protected function getMergeFieldsMap($fields = array())
     {
         $data = new ArrayData(array());
 


### PR DESCRIPTION
Annoying having to copy this method if you want to replace "process" in an extending class so we'll make it a bit looser shall we?