### PR TITLE
Update UserDefinedForm_EmailRecipient::getEmailBodyContent to parse shortcodes in Email HTML

### DIFF
--- a/code/model/recipients/UserDefinedForm_EmailRecipient.php
+++ b/code/model/recipients/UserDefinedForm_EmailRecipient.php
@@ -417,7 +417,7 @@ class UserDefinedForm_EmailRecipient extends DataObject
      */
     public function getEmailBodyContent()
     {
-        return $this->SendPlain ? $this->EmailBody : $this->EmailBodyHtml;
+        return $this->SendPlain ? $this->EmailBody : ShortcodeParser::get_active()->parse( $this->EmailBodyHtml );
     }
 
     /**


### PR DESCRIPTION
Fixes #556