### PR TITLE
Changing form ID to be unique.

### DIFF
--- a/code/model/UserDefinedForm.php
+++ b/code/model/UserDefinedForm.php
@@ -459,7 +459,8 @@ class UserDefinedForm_Controller extends Page_Controller
      */
     public function Form()
     {
-        $form = UserForm::create($this);
+        $form = UserForm::create($this, 'Form_' . $this->ID);
+        $form->setFormAction(Controller::join_links($this->Link(), 'Form'));
         $this->generateConditionalJavascript();
         return $form;
     }

--- a/tests/UserDefinedFormControllerTest.php
+++ b/tests/UserDefinedFormControllerTest.php
@@ -23,7 +23,7 @@ class UserDefinedFormControllerTest extends FunctionalTest
 
         $field = $this->objFromFixture('EditableTextField', 'basic-text');
 
-        $response = $this->submitForm('UserForm_Form', null, array($field->Name => 'Basic Value'));
+        $response = $this->submitForm('UserForm_Form_' . $form->ID, null, array($field->Name => 'Basic Value'));
 
         // should have a submitted form field now
         $submitted = DataObject::get('SubmittedFormField', "\"Name\" = 'basic-text-name'");
@@ -68,7 +68,7 @@ class UserDefinedFormControllerTest extends FunctionalTest
 
         // Post with no fields
         $this->get($form->URLSegment);
-        $response = $this->submitForm('UserForm_Form', null, array());
+        $response = $this->submitForm('UserForm_Form_' . $form->ID, null, array());
         $this->assertPartialMatchBySelector(
             '.field .message',
             array('This field is required')
@@ -76,7 +76,7 @@ class UserDefinedFormControllerTest extends FunctionalTest
 
         // Post with all fields, but invalid email
         $this->get($form->URLSegment);
-        $this->submitForm('UserForm_Form', null, array(
+        $this->submitForm('UserForm_Form_' . $form->ID, null, array(
             'required-email' => 'invalid',
             'required-text' => 'bob'
         ));
@@ -87,7 +87,7 @@ class UserDefinedFormControllerTest extends FunctionalTest
 
         // Post with only required
         $this->get($form->URLSegment);
-        $this->submitForm('UserForm_Form', null, array(
+        $this->submitForm('UserForm_Form_' . $form->ID, null, array(
             'required-text' => 'bob'
         ));
         $this->assertPartialMatchBySelector(
@@ -129,7 +129,7 @@ class UserDefinedFormControllerTest extends FunctionalTest
         $controller = new UserDefinedFormControllerTest_Controller($form);
 
         // test form
-        $this->assertEquals($controller->Form()->getName(), 'Form', 'The form is referenced as Form');
+        $this->assertEquals($controller->Form()->getName(), 'Form_' . $form->ID, 'The form is referenced as Form');
         $this->assertEquals($controller->Form()->Fields()->Count(), 1); // disabled SecurityID token fields
         $this->assertEquals($controller->Form()->Actions()->Count(), 1);
         $this->assertEquals(count($controller->Form()->getValidator()->getRequired()), 0);
@@ -225,7 +225,7 @@ class UserDefinedFormControllerTest extends FunctionalTest
         $index = new ArrayData($controller->index());
         $parser = new CSSContentParser($index->renderWith(array('UserDefinedFormControllerTest')));
 
-        $this->checkTemplateIsCorrect($parser);
+        $this->checkTemplateIsCorrect($parser, $form);
     }
 
     public function testRenderingIntoTemplateWithSubstringReplacement()
@@ -238,7 +238,7 @@ class UserDefinedFormControllerTest extends FunctionalTest
         $index = new ArrayData($controller->index());
         $parser = new CSSContentParser($index->renderWith(array('UserDefinedFormControllerTest')));
 
-        $this->checkTemplateIsCorrect($parser);
+        $this->checkTemplateIsCorrect($parser, $form);
     }
     /**
      * Publish a form for use on the frontend
@@ -259,9 +259,9 @@ class UserDefinedFormControllerTest extends FunctionalTest
         return $form;
     }
 
-    public function checkTemplateIsCorrect($parser)
+    public function checkTemplateIsCorrect($parser, $form)
     {
-        $this->assertArrayHasKey(0, $parser->getBySelector('form#UserForm_Form'));
+        $this->assertArrayHasKey(0, $parser->getBySelector('form#UserForm_Form_' . $form->ID));
 
         // check for the input
         $this->assertArrayHasKey(0, $parser->getBySelector('input.text'));


### PR DESCRIPTION
Having multiple `UserDefinedForms` on one page has an issue in that every form has the same `id` HTML attribute value of `UserForm_Form`. This causes problems.

This pull request changes the form ID to `'UserForm_Form_' . $this->ID` making it unique.

This fixes one of the problems mentioned in issue #543. This is a duplicate of the #565 pull request, but this time done in one commit and after having checked the tests locally before committing.

Note, this may break custom JavaScript validation if people are calling the form by it's ID. This change will require people to instead target the form with the class `.userform` selector.