### PR TITLE
CSS hide when ShowOnLoad false

### DIFF
--- a/code/model/UserDefinedForm.php
+++ b/code/model/UserDefinedForm.php
@@ -766,9 +766,6 @@ JS
 
             $result .= <<<EOS
 \n
-    //Initial state
-    $('{$target}').{$initialState}();
-
     $('.userform').on('{$events}',
     "{$selectors}",
     function (){

--- a/code/model/editableformfields/EditableFormField.php
+++ b/code/model/editableformfields/EditableFormField.php
@@ -862,6 +862,11 @@ class EditableFormField extends DataObject
             $field->addExtraClass($this->ExtraClass);
         }
 
+        // if ShowOnLoad is false hide the field
+        if (!$this->ShowOnLoad) {
+            $field->addExtraClass($this->ShowOnLoadNice());
+        }
+
         // if this field has a placeholder
         if ($this->Placeholder) {
             $field->setAttribute('placeholder', $this->Placeholder);

--- a/css/UserForm.css
+++ b/css/UserForm.css
@@ -72,3 +72,7 @@
   margin-bottom: 5px;
   font-weight: bold;
 }
+
+.userform .field.hide {
+  display: none;
+}


### PR DESCRIPTION
Uses CSS to hide fields with `ShowOnLoad` set to `false` as requested in issue #578 