### PR TITLE
FIX Selector for HTML/plain email content toggle. Show preview button for both.

### DIFF
--- a/code/model/recipients/UserDefinedForm_EmailRecipient.php
+++ b/code/model/recipients/UserDefinedForm_EmailRecipient.php
@@ -258,12 +258,9 @@ class UserDefinedForm_EmailRecipient extends DataObject
                 ->addExtraClass('toggle-html-only'),
             TextareaField::create('EmailBody', _t('UserDefinedForm.EMAILBODY', 'Body'))
                 ->addExtraClass('toggle-plain-only'),
-            LiteralField::create(
-                'EmailPreview',
-                '<div id="EmailPreview" class="field toggle-html-only">' . $preview . '</div>'
-            )
+            LiteralField::create('EmailPreview', $preview)
         ));
-        
+
         $fields->fieldByName('Root.EmailContent')->setTitle(_t('UserDefinedForm_EmailRecipient.EMAILCONTENTTAB', 'Email Content'));
 
         // Custom rules for sending this field

--- a/javascript/Recipient.js
+++ b/javascript/Recipient.js
@@ -5,12 +5,11 @@
 (function ($) {
 	$(document).ready(function () {
 
+        var sendPlain = $('input[name="SendPlain"]');
 		var recipient = {
 			// Some fields are only visible when HTML email are being sent.
 			updateFormatSpecificFields: function () {
-				var sendPlainChecked = $('#SendPlain')
-					.find('input[type="checkbox"]')
-					.is(':checked');
+				var sendPlainChecked = sendPlain.is(':checked');
 
 				$(".field.toggle-html-only")[sendPlainChecked ? 'hide' : 'show']();
 				$(".field.toggle-plain-only")[sendPlainChecked ? 'show' : 'hide']();
@@ -27,7 +26,7 @@
 				}
 			});
 
-			$('#SendPlain').entwine({
+			sendPlain.entwine({
 				onchange: function () {
 					recipient.updateFormatSpecificFields();
 				}


### PR DESCRIPTION
The bug was that the selector ID changed and was no longer valid.

At the same time, I removed the `toggle-html-only` class from the preview button, since it works for both plain and HTML email and I don't see why it shouldn't be used for plain content as well.

Fixes #614 