### PR TITLE
FIX Ensure HTML email preview content is parsed as HTML including shortcodes

### DIFF
--- a/code/model/recipients/UserDefinedForm_EmailRecipient.php
+++ b/code/model/recipients/UserDefinedForm_EmailRecipient.php
@@ -221,7 +221,7 @@ class UserDefinedForm_EmailRecipient extends DataObject
                     'The email address which the recipient is able to \'reply\' to.'
                 ))
         ));
-        
+
         $fields->fieldByName('Root.EmailDetails')->setTitle(_t('UserDefinedForm_EmailRecipient.EMAILDETAILSTAB', 'Email Details'));
 
         // Only show the preview link if the recipient has been saved.
@@ -263,7 +263,7 @@ class UserDefinedForm_EmailRecipient extends DataObject
                 '<div id="EmailPreview" class="field toggle-html-only">' . $preview . '</div>'
             )
         ));
-        
+
         $fields->fieldByName('Root.EmailContent')->setTitle(_t('UserDefinedForm_EmailRecipient.EMAILCONTENTTAB', 'Email Content'));
 
         // Custom rules for sending this field
@@ -288,7 +288,7 @@ class UserDefinedForm_EmailRecipient extends DataObject
             ),
             $grid
         ));
-        
+
         $fields->fieldByName('Root.CustomRules')->setTitle(_t('UserDefinedForm_EmailRecipient.CUSTOMRULESTAB', 'Custom Rules'));
 
         $this->extend('updateCMSFields', $fields);
@@ -417,7 +417,10 @@ class UserDefinedForm_EmailRecipient extends DataObject
      */
     public function getEmailBodyContent()
     {
-        return $this->SendPlain ? $this->EmailBody : $this->EmailBodyHtml;
+        if ($this->SendPlain) {
+            return DBField::create_field('HTMLText', $this->EmailBody)->NoHTML();
+        }
+        return DBField::create_field('HTMLText', $this->EmailBodyHtml)->RAW();
     }
 
     /**

--- a/tests/model/recipients/UserDefinedForm_EmailRecipientTest.php
+++ b/tests/model/recipients/UserDefinedForm_EmailRecipientTest.php
@@ -1,0 +1,24 @@
+<?php
+
+class UserDefinedForm_EmailRecipientTest extends SapphireTest
+{
+    protected static $fixture_file = 'UserDefinedForm_EmailRecipientTest.yml';
+
+    public function testShortcodesAreRenderedInEmailPreviewContent()
+    {
+        $page = $this->objFromFixture('SiteTree', 'about_us');
+
+        $recipient = UserDefinedForm_EmailRecipient::create();
+        $recipient->SendPlain = false;
+        $recipient->EmailBodyHtml = '<p>Some email content. About us: [sitetree_link,id=' . $page->ID . '].</p>';
+
+        $result = $recipient->getEmailBodyContent();
+        $this->assertContains('/about-us/', $result);
+
+        $recipient->SendPlain = true;
+        $recipient->EmailBody = 'Some email content. About us: [sitetree_link,id=' . $page->ID . '].';
+
+        $result = $recipient->getEmailBodyContent();
+        $this->assertContains('/about-us/', $result);
+    }
+}

--- a/tests/model/recipients/UserDefinedForm_EmailRecipientTest.yml
+++ b/tests/model/recipients/UserDefinedForm_EmailRecipientTest.yml
@@ -1,0 +1,4 @@
+SiteTree:
+  about_us:
+    Title: About Us
+    URLSegment: about-us


### PR DESCRIPTION
Follow on from #559 (then #613) which became a little stale (cc @micschk and @dhensby)

Fixes #556 and parses shortcodes for HTML and non-HTML content.

Note that #614 may prevent this from being tested in the CMS.