### PR TITLE
FIX Pass submissions GridFieldConfig to GridField constructor to avoid error in state

### DIFF
--- a/code/model/UserDefinedForm.php
+++ b/code/model/UserDefinedForm.php
@@ -118,14 +118,13 @@ class UserDefinedForm extends Page
     /**
      * @return FieldList
      */
-     public function getCMSFields()
-     {
-         Requirements::css(USERFORMS_DIR . '/css/UserForm_cms.css');
+    public function getCMSFields()
+    {
+        Requirements::css(USERFORMS_DIR . '/css/UserForm_cms.css');
 
-         $self = $this;
+        $self = $this;
 
-         $this->beforeUpdateCMSFields(function ($fields) use ($self) {
-
+        $this->beforeUpdateCMSFields(function ($fields) use ($self) {
             // define tabs
             $fields->findOrMakeTab('Root.FormOptions', _t('UserDefinedForm.CONFIGURATION', 'Configuration'));
             $fields->findOrMakeTab('Root.Recipients', _t('UserDefinedForm.RECIPIENTS', 'Recipients'));
@@ -167,12 +166,6 @@ class UserDefinedForm extends Page
 
 
             // view the submissions
-            $submissions = new GridField(
-                'Submissions',
-                _t('UserDefinedForm.SUBMISSIONS', 'Submissions'),
-                 $self->Submissions()->sort('Created', 'DESC')
-            );
-
             // make sure a numeric not a empty string is checked against this int column for SQL server
             $parentID = (!empty($self->ID)) ? (int) $self->ID : 0;
 
@@ -229,23 +222,33 @@ SQL;
             $export->setCsvHasHeader(true);
             $export->setExportColumns($columns);
 
-            $submissions->setConfig($config);
+            $submissions = GridField::create(
+                'Submissions',
+                _t('UserDefinedForm.SUBMISSIONS', 'Submissions'),
+                $self->Submissions()->sort('Created', 'DESC'),
+                $config
+            );
             $fields->addFieldToTab('Root.Submissions', $submissions);
-            $fields->addFieldToTab('Root.FormOptions', new CheckboxField('DisableSaveSubmissions', _t('UserDefinedForm.SAVESUBMISSIONS', 'Disable Saving Submissions to Server')));
-
+            $fields->addFieldToTab(
+                'Root.FormOptions',
+                CheckboxField::create(
+                    'DisableSaveSubmissions',
+                    _t('UserDefinedForm.SAVESUBMISSIONS', 'Disable Saving Submissions to Server')
+                )
+            );
         });
 
-         $fields = parent::getCMSFields();
+        $fields = parent::getCMSFields();
 
-         if ($this->EmailRecipients()->Count() == 0 && static::config()->recipients_warning_enabled) {
-             $fields->addFieldToTab("Root.Main", new LiteralField("EmailRecipientsWarning",
+        if ($this->EmailRecipients()->Count() == 0 && static::config()->recipients_warning_enabled) {
+            $fields->addFieldToTab("Root.Main", new LiteralField("EmailRecipientsWarning",
                 "<p class=\"message warning\">" . _t("UserDefinedForm.NORECIPIENTS",
                 "Warning: You have not configured any recipients. Form submissions may be missed.")
                 . "</p>"), "Title");
-         }
+        }
 
-         return $fields;
-     }
+        return $fields;
+    }
 
     /**
      * Allow overriding the EmailRecipients on a {@link DataExtension}


### PR DESCRIPTION
This framework bug causes the submissions GridField to lose the filter context when exporting as CSV. Passing the config directly to the GridField constructor allows the state to be set containing the config, where setting it after construction will lose this context. This will be fixed in SS 3.5.x and 3.6.x core releases, but this fix patches it for userforms anyway.

Also some whitespace and PSR-2 compat fixing.

---

Issue caused by https://github.com/silverstripe/silverstripe-framework/issues/6886.

Fixes #620 