### PR TITLE
Use get_by_id on display rules model loads to ensure they get cached

### DIFF
--- a/code/model/UserDefinedForm.php
+++ b/code/model/UserDefinedForm.php
@@ -455,7 +455,7 @@ class UserDefinedForm_Controller extends Page_Controller
                 foreach ($field->EffectiveDisplayRules() as $rule) {
 
                     // Get the field which is effected
-                    $formFieldWatch = EditableFormField::get()->byId($rule->ConditionFieldID);
+                    $formFieldWatch = DataObject::get_by_id('EditableFormField', $rule->ConditionFieldID);
 
                     // Skip deleted fields
                     if (!$formFieldWatch) {


### PR DESCRIPTION
Small change to reduce the number of database queries performed when loading a user defined form with display rules.