### PR TITLE
Update minimum required framework/cms version to 3.2

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -30,8 +30,8 @@
         }
     ],
     "require": {
-        "silverstripe/framework": "~3.1",
-        "silverstripe/cms": "~3.1",
+        "silverstripe/framework": "~3.2",
+        "silverstripe/cms": "~3.2",
         "silverstripe-australia/gridfieldextensions": "~1.1",
         "silverstripe/segment-field": "^1.0"
     },


### PR DESCRIPTION
UserFormsUpgradeService uses DB::get_schema() which was introduced
in framework 3.2 as part of the database abstraction overhaul.

This now ensures the module requires at least that version.