### PR TITLE
Updated package requirement

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -32,7 +32,7 @@
     "require": {
         "silverstripe/framework": "~3.2",
         "silverstripe/cms": "~3.2",
-        "silverstripe-australia/gridfieldextensions": "~1.1",
+        "symbiote/silverstripe-gridfieldextensions": "~1.4",
         "silverstripe/segment-field": "^1.0"
     },
     "suggest": {


### PR DESCRIPTION
silverstripe-australia/gridfieldextensions is abandoned.