### PR TITLE
Remove default value field from EditableFileField

### DIFF
--- a/code/model/editableformfields/EditableFileField.php
+++ b/code/model/editableformfields/EditableFileField.php
@@ -45,10 +45,14 @@ class EditableFileField extends EditableFormField
             )
         );
 
-        $fields->addFieldToTab("Root.Main", new LiteralField("FileUploadWarning",
-            "<p class=\"message notice\">" . _t("UserDefinedForm.FileUploadWarning",
-                "Files uploaded through this field could be publicly accessible if the exact URL is known")
-            . "</p>"), "Type");
+        $fields->addFieldToTab("Root.Main", new LiteralField(
+            "FileUploadWarning",
+            "<p class=\"message notice\">"
+            . _t(
+                "UserDefinedForm.FileUploadWarning",
+                "Files uploaded through this field could be publicly accessible if the exact URL is known"
+            ) . "</p>"
+        ), "Type");
 
         $fields->addFieldToTab(
             'Root.Main',
@@ -56,6 +60,8 @@ class EditableFileField extends EditableFormField
                 ->setTitle('Max File Size MB')
                 ->setDescription("Note: Maximum php allowed size is {$this->getPHPMaxFileSizeMB()} MB")
         );
+
+        $fields->removeByName('Default');
 
         return $fields;
     }


### PR DESCRIPTION
The "default value" field is inherited in CMS fields when editing a file field. It has no relevance to uploading a file field, so this PR removes it from the CMS fields.