### PR TITLE
FIX Alias object context in closure for PHP 5.3 compat, add test to cover it

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,8 @@ sudo: false
 
 language: php
 
+dist: precise
+
 matrix:
   include:
     - php: 5.3

--- a/code/model/editableformfields/EditableTextField.php
+++ b/code/model/editableformfields/EditableTextField.php
@@ -61,7 +61,10 @@ class EditableTextField extends EditableFormField
 
     public function getCMSFields()
     {
-        $this->beforeUpdateCMSFields(function ($fields) {
+        // PHP 5.3 compat
+        $self = $this;
+
+        $this->beforeUpdateCMSFields(function ($fields) use ($self) {
             $fields->addFieldToTab(
                 'Root.Main',
                 NumericField::create(
@@ -78,7 +81,7 @@ class EditableTextField extends EditableFormField
                 DropdownField::create(
                     'Autocomplete',
                     _t('EditableTextField.AUTOCOMPLETE', 'Autocomplete'),
-                    $this->config()->get('autocomplete_options')
+                    $self->config()->get('autocomplete_options')
                   )->setDescription(_t(
                       'EditableTextField.AUTOCOMPLETE_DESCRIPTION',
                       'Supported browsers will attempt to populate this field automatically with the users information, use to set the value populated'

--- a/tests/Model/EditableFormField/EditableTextFieldTest.php
+++ b/tests/Model/EditableFormField/EditableTextFieldTest.php
@@ -1,0 +1,17 @@
+<?php
+
+class EditableTextFieldTest extends SapphireTest
+{
+    public function testGetCmsFields()
+    {
+        Config::inst()->remove('EditableTextField', 'autocomplete_options');
+        Config::inst()->update('EditableTextField', 'autocomplete_options', array('foo' => 'foo'));
+
+        $field = new EditableTextField;
+        $result = $field->getCMSFields();
+
+        $autocompleteField = $result->fieldByName('Root.Main.Autocomplete');
+        $this->assertInstanceOf('DropdownField', $autocompleteField);
+        $this->assertEquals(array('foo' => 'foo'), $autocompleteField->getSource());
+    }
+}


### PR DESCRIPTION
It's a new test class, so I've added it in the location that it will end up in when merged up for SS4

Fixes #646 