### PR TITLE
FIX Escape dollar signs in UserForm contents before inserting them with regex

### DIFF
--- a/code/model/UserDefinedForm.php
+++ b/code/model/UserDefinedForm.php
@@ -411,7 +411,9 @@ class UserDefinedForm_Controller extends Page_Controller
         if ($this->Content && $form = $this->Form()) {
             $hasLocation = stristr($this->Content, '$UserDefinedForm');
             if ($hasLocation) {
-                $content = preg_replace('/(<p[^>]*>)?\\$UserDefinedForm(<\\/p>)?/i', $form->forTemplate(), $this->Content);
+                /** @see Requirements_Backend::escapeReplacement */
+                $formEscapedForRegex = addcslashes($form->forTemplate(), '\\$');
+                $content = preg_replace('/(<p[^>]*>)?\\$UserDefinedForm(<\\/p>)?/i', $formEscapedForRegex, $this->Content);
                 return array(
                     'Content' => DBField::create_field('HTMLText', $content),
                     'Form' => ""

--- a/templates/forms/UserFormsCheckboxSetField.ss
+++ b/templates/forms/UserFormsCheckboxSetField.ss
@@ -3,7 +3,7 @@
         <div class="$Class">
             <input id="$ID" class="checkbox" name="$Name" type="checkbox" value="$Value.ATT"<% if $isChecked %>
                    checked="checked"<% end_if %><% if $isDisabled %> disabled="disabled"<% end_if %> />
-            <label for="$ID">$Title</label>
+            <label for="$ID">$Title.XML</label>
         </div>
     <% end_loop %>
 <% else %>


### PR DESCRIPTION
The contents of `$form->forTemplate()` returns correctly, but when used as a regex substitution occurrences of e.g. `$2`, `$5` etc are treated as regex references and replaced with nothing.

Ideally we'd use a DOM parser here, but the way that the UDF works is sort of like content blocks in that the `$UserDefinedForm` marker can exist anywhere in the content, which means we could have invalid HTML markup like this:

```html
<h1>hello</h1>
$UserDefinedForm
<p>Content here</p>
```

A DOM parser wouldn't work here since this is invalid markup. We could change to using something other than `$UserDefinedForm`, but would be a breaking change.

For now, this will at least escape dollar signs in the form's contents before using it as a regex replacement.

This will mean literal field values and labels like `$2` and `$25` will work. We will still run into danger by adding leading slashes to them, e.g. `\$2`, since this will counter the escaping and cause `$2` to render as blank, but as long as users notice this they can add an extra slash to "fix" it.

I think this is the best we can do for now without moving to a simple `str_replace` which would leave paragraph tags around the form.

Fixes #659 