### PR TITLE
fix for broken validation on optionsets

### DIFF
--- a/javascript/UserForm.js
+++ b/javascript/UserForm.js
@@ -84,9 +84,9 @@ jQuery(function ($) {
 			error.addClass('message');
 
 			if (element.is(':radio') || element.parents('.checkboxset').length > 0) {
-				error.insertAfter(element.closest('ul'));
+				error.appendTo(element.closest('.middleColumn'));
 			} else if (element.parents('.checkbox').length > 0) {
-				error.insertAfter(element.next('label'));
+				error.appendTo(element.closest('.field'));
 			} else {
 				error.insertAfter(element);
 			}


### PR DESCRIPTION
Since removing the unordered list from optionsets in 4.5.0, the validation fails to display validation messages. This corrects the positioning.