### PR TITLE
Update default email_template_directory

### DIFF
--- a/code/Model/Recipient/EmailRecipient.php
+++ b/code/Model/Recipient/EmailRecipient.php
@@ -369,7 +369,8 @@ class EmailRecipient extends DataObject
             $fields->insertBefore(
                 DropdownField::create(
                     'EmailTemplate',
-                    _t('SilverStripe\\UserForms\\Model\\UserDefinedForm.EMAILTEMPLATE', 'Email template')
+                    _t('SilverStripe\\UserForms\\Model\\UserDefinedForm.EMAILTEMPLATE', 'Email template'),
+                    $templates
                 )->addExtraClass('toggle-html-only'),
                 'EmailBodyHtml'
             );
@@ -527,7 +528,7 @@ class EmailRecipient extends DataObject
     {
         $t = ($template ? $template : $this->EmailTemplate);
 
-        return array_key_exists($t, $this->getEmailTemplateDropdownValues());
+        return array_key_exists($t, (array) $this->getEmailTemplateDropdownValues());
     }
 
     /**

--- a/code/Model/Recipient/EmailRecipient.php
+++ b/code/Model/Recipient/EmailRecipient.php
@@ -37,6 +37,8 @@ use SilverStripe\UserForms\UserForm;
 use SilverStripe\View\Requirements;
 use Symbiote\GridFieldExtensions\GridFieldAddNewInlineButton;
 use Symbiote\GridFieldExtensions\GridFieldEditableColumns;
+use SilverStripe\Core\Manifest\ModuleResourceLoader;
+use SilverStripe\Core\Config\Config;
 
 /**
  * A Form can have multiply members / emails to email the submission
@@ -348,11 +350,6 @@ class EmailRecipient extends DataObject
                     'Send email as plain text? (HTML will be stripped)'
                 )
             ),
-            DropdownField::create(
-                'EmailTemplate',
-                _t('SilverStripe\\UserForms\\Model\\UserDefinedForm.EMAILTEMPLATE', 'Email template'),
-                $this->getEmailTemplateDropdownValues()
-            )->addExtraClass('toggle-html-only'),
             HTMLEditorField::create(
                 'EmailBodyHtml',
                 _t('SilverStripe\\UserForms\\Model\\UserDefinedForm.EMAILBODYHTML', 'Body')
@@ -365,6 +362,18 @@ class EmailRecipient extends DataObject
                 ->addExtraClass('toggle-plain-only'),
             LiteralField::create('EmailPreview', $preview)
         ]);
+
+        $templates = $this->getEmailTemplateDropdownValues();
+
+        if ($templates) {
+            $fields->insertBefore(
+                DropdownField::create(
+                    'EmailTemplate',
+                    _t('SilverStripe\\UserForms\\Model\\UserDefinedForm.EMAILTEMPLATE', 'Email template')
+                )->addExtraClass('toggle-html-only'),
+                'EmailBodyHtml'
+            );
+        }
 
         $fields->fieldByName('Root.EmailContent')->setTitle(_t(__CLASS__.'.EMAILCONTENTTAB', 'Email Content'));
 
@@ -546,13 +555,20 @@ class EmailRecipient extends DataObject
         $finder = new FileFinder();
         $finder->setOption('name_regex', '/^.*\.ss$/');
 
-        $templateDirectory = UserDefinedForm::config()->get('email_template_directory');
-        // Handle cases where "userforms" might not be the base module directory, e.g. in a Travis build
-        if (!file_exists(BASE_PATH . DIRECTORY_SEPARATOR . $templateDirectory)
-            && substr($templateDirectory, 0, 10) === 'userforms/'
-        ) {
-            $templateDirectory = substr($templateDirectory, 10);
+        $parent = $this->getFormParent();
+
+        if (!$parent) {
+            return [];
         }
+
+        $templateDirectory = ModuleResourceLoader::resourcePath(
+            $parent->config()->get('email_template_directory')
+        );
+
+        if (!$templateDirectory) {
+            return [];
+        }
+
         $found = $finder->find(BASE_PATH . DIRECTORY_SEPARATOR . $templateDirectory);
 
         foreach ($found as $key => $value) {
@@ -562,14 +578,6 @@ class EmailRecipient extends DataObject
                 strlen(BASE_PATH) + 1
             );
 
-            $defaultPrefixes = ['userforms/templates/', 'templates/'];
-            foreach ($defaultPrefixes as $defaultPrefix) {
-                // Remove default userforms folder if it's provided
-                if (substr($templatePath, 0, strlen($defaultPrefix)) === $defaultPrefix) {
-                    $templatePath = substr($templatePath, strlen($defaultPrefix));
-                    break;
-                }
-            }
             $templates[$templatePath] = $template['filename'];
         }
 

--- a/code/UserForm.php
+++ b/code/UserForm.php
@@ -36,6 +36,7 @@ use SilverStripe\UserForms\Model\Recipient\UserFormRecipientItemRequest;
 use SilverStripe\UserForms\Model\Submission\SubmittedForm;
 use SilverStripe\UserForms\Model\EditableFormField;
 use SilverStripe\View\Requirements;
+use SilverStripe\Core\Config\Configurable;
 
 /**
  * Defines the user defined functionality to be applied to any {@link DataObject}
@@ -43,6 +44,8 @@ use SilverStripe\View\Requirements;
  */
 trait UserForm
 {
+    use Configurable;
+
     /**
      * Built in extensions required by this page.
      *
@@ -61,7 +64,7 @@ trait UserForm
     /**
      * @var string
      */
-    private static $email_template_directory = 'userforms/templates/email/';
+    private static $email_template_directory = 'silverstripe/userforms:templates/email/';
 
     /**
      * Should this module automatically upgrade on dev/build?

--- a/tests/Model/UserDefinedFormTest.php
+++ b/tests/Model/UserDefinedFormTest.php
@@ -158,16 +158,22 @@ class UserDefinedFormTest extends FunctionalTest
 
     public function testGetEmailTemplateDropdownValues()
     {
+        $page = $this->objFromFixture(UserDefinedForm::class, 'basic-form-page');
         $recipient = new EmailRecipient();
+        $recipient->FormID = $page->ID;
 
-        $defaultValues = ['email/SubmittedFormEmail' => 'SubmittedFormEmail'];
+        $result = $recipient->getEmailTemplateDropdownValues();
 
-        $this->assertEquals($recipient->getEmailTemplateDropdownValues(), $defaultValues);
+        // Installation path can be as a project when testing in Travis, so check partial match
+        $this->assertContains('templates/email/SubmittedFormEmail', key($result));
+        $this->assertSame('SubmittedFormEmail', current($result));
     }
 
     public function testEmailTemplateExists()
     {
+        $page = $this->objFromFixture(UserDefinedForm::class, 'basic-form-page');
         $recipient = new EmailRecipient();
+        $recipient->FormID = $page->ID;
 
         // Set the default template
         $recipient->EmailTemplate = current(array_keys($recipient->getEmailTemplateDropdownValues()));
@@ -192,10 +198,9 @@ class UserDefinedFormTest extends FunctionalTest
             $this->assertTrue($recipient->canDelete());
         }
 
-        $member = Member::currentUser();
-        $member->logOut();
-
+        $this->logOut();
         $this->logInWithPermission('SITETREE_VIEW_ALL');
+
         foreach ($form->EmailRecipients() as $recipient) {
             $this->assertFalse($recipient->canEdit());
             $this->assertFalse($recipient->canDelete());


### PR DESCRIPTION
Also if the overridded directory is empty - don’t display the template dropdown as this will cause a validation error preventing the user from saving the page.