### PR TITLE
FIX Polymorphic has_one needs parent class name set

### DIFF
--- a/code/Control/UserDefinedFormController.php
+++ b/code/Control/UserDefinedFormController.php
@@ -205,6 +205,7 @@ JS
     {
         $submittedForm = SubmittedForm::create();
         $submittedForm->SubmittedByID = Security::getCurrentUser() ? Security::getCurrentUser()->ID : 0;
+        $submittedForm->ParentClass = get_class($this->data());
         $submittedForm->ParentID = $this->ID;
 
         // if saving is not disabled save now to generate the ID


### PR DESCRIPTION
The relationship was changed to polymorphic in #672, this PR ensures that the correct class name is set, not a random DataObject.