### PR TITLE
FIX Explicitly get the Fields() method from controller's data record

### DIFF
--- a/code/Control/UserDefinedFormController.php
+++ b/code/Control/UserDefinedFormController.php
@@ -166,9 +166,9 @@ class UserDefinedFormController extends PageController
 
         $watch = [];
 
-        if ($this->Fields()) {
+        if ($this->data()->Fields()) {
             /** @var EditableFormField $field */
-            foreach ($this->Fields() as $field) {
+            foreach ($this->data()->Fields() as $field) {
                 if ($result = $field->formatDisplayRules()) {
                     $watch[] = $result;
                 }
@@ -216,7 +216,7 @@ JS
         $attachments = array();
         $submittedFields = ArrayList::create();
 
-        foreach ($this->Fields() as $field) {
+        foreach ($this->data()->Fields() as $field) {
             if (!$field->showInReports()) {
                 continue;
             }

--- a/code/Form/UserForm.php
+++ b/code/Form/UserForm.php
@@ -122,7 +122,7 @@ class UserForm extends Form
         $fields = new UserFormsFieldList();
         $target = $fields;
 
-        foreach ($this->controller->Fields() as $field) {
+        foreach ($this->controller->data()->Fields() as $field) {
             $target = $target->processNext($field);
         }
         $fields->clearEmptySteps();
@@ -170,6 +170,7 @@ class UserForm extends Form
         // Generate required field validator
         $requiredNames = $this
             ->getController()
+            ->data()
             ->Fields()
             ->filter('Required', true)
             ->column('Name');


### PR DESCRIPTION
Prevents error when using the UserForm trait on an arbitrary DataObject:

```
[Emergency] Uncaught BadMethodCallException: Object->__call(): the method 'Fields' does not exist on 'SilverStripe\UserForms\Control\UserDefinedFormController'
```

For context, the `Fields()` method is a has_many relationship to EditableFormField, which is applied to whatever uses the UserForm trait (in this module it's UserDefinedForm) by the UserFormFieldEditorExtension.

This change is non-breaking for userforms, since the method exists on the data record rather than the controller anyway, but allows other DataObjects that use the UserForm trait to still push to the Form action in the controller without having this error.