### PR TITLE
FIX Update getIcon resource resolution methods

### DIFF
--- a/code/Model/EditableFormField.php
+++ b/code/Model/EditableFormField.php
@@ -599,8 +599,17 @@ class EditableFormField extends DataObject
      */
     public function getIcon()
     {
-        return ModuleLoader::getModule('silverstripe/userforms')
-            ->getRelativeResourcePath('images/' . strtolower($this->class) . '.png');
+        $classNamespaces = explode("\\", static::class);
+        $shortClass = end($classNamespaces);
+
+        $resource = ModuleLoader::getModule('silverstripe/userforms')
+            ->getResource('images/' . strtolower($shortClass) . '.png');
+
+        if (!$resource->exists()) {
+            return '';
+        }
+
+        return $resource->getURL();
     }
 
     /**

--- a/code/Model/EditableFormField/EditableCountryDropdownField.php
+++ b/code/Model/EditableFormField/EditableCountryDropdownField.php
@@ -55,8 +55,13 @@ class EditableCountryDropdownField extends EditableFormField
 
     public function getIcon()
     {
-        return ModuleLoader::getModule('silverstripe/userforms')
-            ->getRelativeResourcePath('images/editabledropdown.png');
+        $resource = ModuleLoader::getModule('silverstripe/userforms')->getResource('images/editabledropdown.png');
+
+        if (!$resource->exists()) {
+            return '';
+        }
+
+        return $resource->getURL();
     }
 
     public function getSelectorField(EditableCustomRule $rule, $forOnLoad = false)

--- a/tests/Model/EditableFormField/EditableCountryDropdownFieldTest.php
+++ b/tests/Model/EditableFormField/EditableCountryDropdownFieldTest.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace SilverStripe\UserForms\Tests\Model\EditableFormField;
+
+use SilverStripe\Dev\SapphireTest;
+use SilverStripe\UserForms\Model\EditableFormField\EditableCountryDropdownField;
+
+class EditableCountryDropdownFieldTest extends SapphireTest
+{
+    public function testGetIcon()
+    {
+        $field = new EditableCountryDropdownField;
+
+        $this->assertContains('/images/editabledropdown.png', $field->getIcon());
+    }
+}

--- a/tests/Model/EditableFormFieldTest.php
+++ b/tests/Model/EditableFormFieldTest.php
@@ -229,4 +229,11 @@ class EditableFormFieldTest extends FunctionalTest
         // The opposite method should be to return it to its original state, i.e. show it again
         $this->assertSame('removeClass("hide")', $displayRules['opposite']);
     }
+
+    public function testGetIcon()
+    {
+        $field = new EditableTextField;
+
+        $this->assertContains('/images/editabletextfield.png', $field->getIcon());
+    }
 }


### PR DESCRIPTION
What was there originally was using `$this->class` which has been removed from core, and doesn't factor in namespaced classes.