### PR TITLE
Make sure jQuery is available before using it for conditional logic rules

### DIFF
--- a/code/Control/UserDefinedFormController.php
+++ b/code/Control/UserDefinedFormController.php
@@ -182,11 +182,13 @@ class UserDefinedFormController extends PageController
         // Only add customScript if $default or $rules is defined
         if ($rules) {
             Requirements::customScript(<<<JS
-                (function($) {
+                function initUDFRules() {
+                    if (!window.jQuery) return setTimeout(initUDFRules, 50);
                     $(document).ready(function() {
                         {$rules}
                     });
-                })(jQuery);
+                };
+                initUDFRules();
 JS
             , 'UserFormsConditional');
         }


### PR DESCRIPTION
This is needed when jQuery is loaded asynchronously or after the inserted JS snippet and is therefore available after the JS for conditional rules is first processed.