### PR TITLE
FIX Email templates for submissions to display correctly, and attach files to emails

### DIFF
--- a/code/Control/UserDefinedFormController.php
+++ b/code/Control/UserDefinedFormController.php
@@ -8,6 +8,7 @@ use SilverStripe\Assets\Upload;
 use SilverStripe\Control\Controller;
 use SilverStripe\Control\Email\Email;
 use SilverStripe\Control\HTTP;
+use SilverStripe\Control\HTTPResponse;
 use SilverStripe\Core\Manifest\ModuleLoader;
 use SilverStripe\Forms\Form;
 use SilverStripe\i18n\i18n;
@@ -200,7 +201,7 @@ JS
      * @param array $data
      * @param Form $form
      *
-     * @return \SilverStripe\Control\HTTPResponse
+     * @return HTTPResponse
      */
     public function process($data, $form)
     {
@@ -214,7 +215,7 @@ JS
             $submittedForm->write();
         }
 
-        $attachments = array();
+        $attachments = [];
         $submittedFields = ArrayList::create();
 
         foreach ($this->data()->Fields() as $field) {

--- a/code/Control/UserDefinedFormController.php
+++ b/code/Control/UserDefinedFormController.php
@@ -7,7 +7,6 @@ use SilverStripe\Assets\File;
 use SilverStripe\Assets\Upload;
 use SilverStripe\Control\Controller;
 use SilverStripe\Control\Email\Email;
-use SilverStripe\Control\HTTP;
 use SilverStripe\Control\HTTPResponse;
 use SilverStripe\Core\Manifest\ModuleLoader;
 use SilverStripe\Forms\Form;
@@ -293,14 +292,15 @@ JS
 
                 if ($attachments) {
                     foreach ($attachments as $file) {
-                        if (!$file->ID != 0) {
+                        /** @var File $file */
+                        if ((int) $file->ID === 0) {
                             continue;
                         }
 
-                        $email->attachFile(
-                            $file->Filename,
-                            $file->Filename,
-                            HTTP::get_mime_type($file->Filename)
+                        $email->addAttachmentFromData(
+                            $file->getString(),
+                            $file->getFilename(),
+                            $file->getMimeType()
                         );
                     }
                 }

--- a/code/Model/Recipient/EmailRecipientCondition.php
+++ b/code/Model/Recipient/EmailRecipientCondition.php
@@ -4,8 +4,10 @@ namespace SilverStripe\UserForms\Model\Recipient;
 
 use LogicException;
 use SilverStripe\CMS\Controllers\CMSMain;
+use SilverStripe\CMS\Model\SiteTree;
 use SilverStripe\Control\Controller;
 use SilverStripe\ORM\DataObject;
+use SilverStripe\Security\Member;
 use SilverStripe\UserForms\Model\Recipient\EmailRecipient;
 use SilverStripe\UserForms\Model\EditableFormField;
 
@@ -142,31 +144,16 @@ class EmailRecipientCondition extends DataObject
         return null;
     }
 
-    /**
-     * @param Member
-     *
-     * @return boolean
-     */
     public function canView($member = null)
     {
         return $this->Parent()->canView($member);
     }
 
-    /**
-     * @param Member
-     *
-     * @return boolean
-     */
     public function canEdit($member = null)
     {
         return $this->Parent()->canEdit($member);
     }
 
-    /**
-     * @param Member
-     *
-     * @return boolean
-     */
     public function canDelete($member = null)
     {
         return $this->canEdit($member);

--- a/code/Model/Recipient/UserFormRecipientItemRequest.php
+++ b/code/Model/Recipient/UserFormRecipientItemRequest.php
@@ -6,8 +6,8 @@ use SilverStripe\Core\Config\Config;
 use SilverStripe\Forms\GridField\GridFieldDetailForm_ItemRequest;
 use SilverStripe\ORM\ArrayList;
 use SilverStripe\ORM\FieldType\DBField;
-use SilverStripe\UserForms\Model\EditableFormField\EditableLiteralField;
 use SilverStripe\UserForms\Model\EditableFormField\EditableFormHeading;
+use SilverStripe\UserForms\Model\EditableFormField\EditableLiteralField;
 use SilverStripe\View\ArrayData;
 use SilverStripe\View\SSViewer;
 
@@ -34,11 +34,11 @@ class UserFormRecipientItemRequest extends GridFieldDetailForm_ItemRequest
         Config::nest();
         Config::modify()->set(SSViewer::class, 'theme_enabled', true);
 
-        $content = $this->customise(ArrayData::create([
+        $content = $this->customise([
             'Body' => $this->record->getEmailBodyContent(),
-            'HideFormData' => $this->record->HideFormData,
+            'HideFormData' => (bool) $this->record->HideFormData,
             'Fields' => $this->getPreviewFieldData()
-        ]))->renderWith($this->record->EmailTemplate);
+        ])->renderWith($this->record->EmailTemplate);
 
         Config::unnest();
 

--- a/templates/email/SubmittedFormEmail.ss
+++ b/templates/email/SubmittedFormEmail.ss
@@ -1,10 +1,9 @@
 $Body
 
-<% if HideFormData %>
-<% else %>
+<% if not $HideFormData %>
 	<dl>
-		<% loop Fields %>
-			<dt><strong><% if Title %>$Title<% else %>$Name<% end_if %></strong></dt>
+		<% loop $Fields %>
+			<dt><strong><% if $Title %>$Title<% else %>$Name<% end_if %></strong></dt>
 			<dd style="margin: 4px 0 14px 0">$FormattedValue</dd>
 		<% end_loop %>
 	</dl>

--- a/tests/Model/UserDefinedFormTest.php
+++ b/tests/Model/UserDefinedFormTest.php
@@ -11,13 +11,12 @@ use SilverStripe\Forms\Form;
 use SilverStripe\Forms\GridField\GridField;
 use SilverStripe\Forms\GridField\GridFieldDataColumns;
 use SilverStripe\ORM\DB;
-use SilverStripe\Security\Member;
 use SilverStripe\UserForms\Extension\UserFormFieldEditorExtension;
 use SilverStripe\UserForms\Extension\UserFormValidator;
 use SilverStripe\UserForms\Model\EditableCustomRule;
 use SilverStripe\UserForms\Model\EditableFormField;
-use SilverStripe\UserForms\Model\EditableFormField\EditableEmailField;
 use SilverStripe\UserForms\Model\EditableFormField\EditableDropdown;
+use SilverStripe\UserForms\Model\EditableFormField\EditableEmailField;
 use SilverStripe\UserForms\Model\EditableFormField\EditableFieldGroup;
 use SilverStripe\UserForms\Model\EditableFormField\EditableFieldGroupEnd;
 use SilverStripe\UserForms\Model\Recipient\EmailRecipient;
@@ -165,7 +164,7 @@ class UserDefinedFormTest extends FunctionalTest
         $result = $recipient->getEmailTemplateDropdownValues();
 
         // Installation path can be as a project when testing in Travis, so check partial match
-        $this->assertContains('templates/email/SubmittedFormEmail', key($result));
+        $this->assertContains('email/SubmittedFormEmail', key($result));
         $this->assertSame('SubmittedFormEmail', current($result));
     }
 


### PR DESCRIPTION
Fixes #699 and fixes #694.

Also fixes an issue with previewing email templates in the CMS reporting that it is unable to find vendorise templates, e.g. `vendor/silverstripe/userforms/templates/email/MyTemplate`. This change is covered by existing tests.