### PR TITLE
 FIX Submitted form field data is rendered correctly in recipient email templates

### DIFF
--- a/code/Control/UserDefinedFormController.php
+++ b/code/Control/UserDefinedFormController.php
@@ -276,7 +276,9 @@ JS
 
         $emailData = [
             'Sender' => Security::getCurrentUser(),
-            'Fields' => $submittedFields
+            'HideFormData' => false,
+            'Fields' => $submittedFields,
+            'Body' => '',
         ];
 
         $this->extend('updateEmailData', $emailData, $attachments);
@@ -285,9 +287,10 @@ JS
         if ($recipients = $this->FilteredEmailRecipients($data, $form)) {
             foreach ($recipients as $recipient) {
                 $email = Email::create()
-                    ->setHTMLTemplate('email/SubmittedFormEmail.ss')
-                    ->setPlainTemplate('email/SubmittedFormEmail.ss');
+                    ->setHTMLTemplate('email/SubmittedFormEmail')
+                    ->setPlainTemplate('email/SubmittedFormEmail');
 
+                // Merge fields are used for CMS authors to reference specific form fields in email content
                 $mergeFields = $this->getMergeFieldsMap($emailData['Fields']);
 
                 if ($attachments) {
@@ -305,19 +308,21 @@ JS
                     }
                 }
 
-                $parsedBody = SSViewer::execute_string($recipient->getEmailBodyContent(), $mergeFields);
-
                 if (!$recipient->SendPlain && $recipient->emailTemplateExists()) {
                     $email->setHTMLTemplate($recipient->EmailTemplate);
                 }
 
-                $email->setData($recipient);
+                // Add specific template data for the current recipient
+                $emailData['HideFormData'] =  (bool) $recipient->HideFormData;
+                // Include any parsed merge field references from the CMS editor - this is already escaped
+                $emailData['Body'] = SSViewer::execute_string($recipient->getEmailBodyContent(), $mergeFields);
+
+                // Push the template data to the Email's data
                 foreach ($emailData as $key => $value) {
                     $email->addData($key, $value);
                 }
 
                 $email->setFrom($recipient->EmailFrom);
-                $email->setBody($parsedBody);
                 $email->setTo($recipient->EmailAddress);
                 $email->setSubject($recipient->EmailSubject);
 
@@ -353,11 +358,11 @@ JS
 
                 $this->extend('updateEmail', $email, $recipient, $emailData);
 
-                if ($recipient->SendPlain) {
+                if ((bool)$recipient->SendPlain) {
                     $body = strip_tags($recipient->getEmailBodyContent()) . "\n";
-                    if (isset($emailData['Fields']) && !$recipient->HideFormData) {
-                        foreach ($emailData['Fields'] as $Field) {
-                            $body .= $Field->Title . ': ' . $Field->Value . " \n";
+                    if (isset($emailData['Fields']) && !$emailData['HideFormData']) {
+                        foreach ($emailData['Fields'] as $field) {
+                            $body .= $field->Title . ': ' . $field->Value . " \n";
                         }
                     }
 

--- a/templates/email/SubmittedFormEmail.ss
+++ b/templates/email/SubmittedFormEmail.ss
@@ -1,4 +1,5 @@
-$Body
+<%-- Note: content is already escaped in UserDefinedFormController::process --%>
+$Body.RAW
 
 <% if not $HideFormData %>
 	<dl>


### PR DESCRIPTION
Fixes #695 

Regression tested form submissions with:

* plain email template with submitted fields
* HTML email template with submitted fields
* plain email template without submitted fields
* HTML email template without submitted fields
* plain email template without a body, with submitted fields
* plain email template without a body, without submitted fields (entirely empty)
* HTML email template without a body, with submitted fields
* HTML email template without a body, without submitted fields (entirely empty)
* submitted files attached to recipient emails
* Adding merge fields into the Body content field

Unit tests cover some of this already.