### PR TITLE
FIX Update display rules not enabled warning message to be full width

### DIFF
--- a/code/Model/EditableFormField.php
+++ b/code/Model/EditableFormField.php
@@ -343,14 +343,14 @@ class EditableFormField extends DataObject
     {
         // Check display rules
         if ($this->Required) {
-            return new FieldList(
-                LabelField::create(
-                    _t(
+            return FieldList::create(
+                LiteralField::create(
+                    'DisplayRulesNotEnabled',
+                    '<div class="alert alert-warning">' . _t(
                         __CLASS__.'.DISPLAY_RULES_DISABLED',
                         'Display rules are not enabled for required fields. Please uncheck "Is this field Required?" under "Validation" to re-enable.'
-                    )
+                    ) . '</div>'
                 )
-                ->addExtraClass('message warning')
             );
         }
 


### PR DESCRIPTION
Before:

![image](https://user-images.githubusercontent.com/5170590/35707085-3c54b70e-080d-11e8-9f2e-d35d2fe83a22.png)

After:

![image](https://user-images.githubusercontent.com/5170590/35709744-cfc263dc-0818-11e8-8c31-611e1659e0a1.png)

