### PR TITLE
adds logic for presence of email recipient fields

### DIFF
--- a/code/Control/UserDefinedFormController.php
+++ b/code/Control/UserDefinedFormController.php
@@ -346,6 +346,8 @@ JS
 
                     if ($submittedFormField && is_string($submittedFormField->Value)) {
                         $email->setTo(explode(',', $submittedFormField->Value));
+                    } else {
+                        $email->setTo(explode(',', $recipient->EmailAddress));
                     }
                 } else {
                     $email->setTo(explode(',', $recipient->EmailAddress));
@@ -357,6 +359,8 @@ JS
 
                     if ($submittedFormField && trim($submittedFormField->Value)) {
                         $email->setSubject($submittedFormField->Value);
+                    } else {
+                        $email->setSubject($recipient->EmailSubject);
                     }
                 } else {
                     $email->setSubject($recipient->EmailSubject);

--- a/code/Form/UserForm.php
+++ b/code/Form/UserForm.php
@@ -222,7 +222,7 @@ class UserForm extends Form
 
         foreach ($this->getController()->data()->EmailRecipients() as $recipient) {
             foreach ($recipientFieldsMap as $textField => $dynamicFormField) {
-                if (empty($recipient->$textField) && $recipient->getComponent($dynamicFormField)) {
+                if (empty($recipient->$textField) && $recipient->getComponent($dynamicFormField)->exists()) {
                     $requiredFields[] = $recipient->getComponent($dynamicFormField)->Name;
                 }
             }

--- a/code/Model/Recipient/EmailRecipient.php
+++ b/code/Model/Recipient/EmailRecipient.php
@@ -613,6 +613,11 @@ class EmailRecipient extends DataObject
                 }
             }
         }
+
+        // if there is no from address and no fallback, you'll have errors if this isn't defined
+        if (!$this->EmailFrom && empty(Email::getSendAllEmailsFrom()) && empty(Email::config()->get('admin)_email'))) {
+            $result->addError(_t(__CLASS__.".EMAILFROMREQUIRED", '"Email From" address is required'));
+        }
         return $result;
     }
 }

--- a/code/Model/Recipient/EmailRecipient.php
+++ b/code/Model/Recipient/EmailRecipient.php
@@ -615,7 +615,7 @@ class EmailRecipient extends DataObject
         }
 
         // if there is no from address and no fallback, you'll have errors if this isn't defined
-        if (!$this->EmailFrom && empty(Email::getSendAllEmailsFrom()) && empty(Email::config()->get('admin)_email'))) {
+        if (!$this->EmailFrom && empty(Email::getSendAllEmailsFrom()) && empty(Email::config()->get('admin_email'))) {
             $result->addError(_t(__CLASS__.".EMAILFROMREQUIRED", '"Email From" address is required'));
         }
         return $result;

--- a/lang/en.yml
+++ b/lang/en.yml
@@ -191,6 +191,7 @@ en:
     EMAILCONTENTTAB: 'Email Content'
     EMAILDETAILSTAB: 'Email Details'
     EMAILFROMINVALID: '"Email From" is not valid'
+    EMAILFROMREQUIRED: '"Email From" address is required'
     EMAILREPLYTOINVALID: '"Email Reply To" is not valid'
     PLURALNAME: 'User Defined Form Email Recipients'
     SINGULARNAME: 'User Defined Form Email Recipient'

--- a/tests/Model/UserDefinedFormTest.php
+++ b/tests/Model/UserDefinedFormTest.php
@@ -3,6 +3,7 @@
 namespace SilverStripe\UserForms\Tests\Model;
 
 use SilverStripe\Control\Controller;
+use SilverStripe\Control\Email\Email;
 use SilverStripe\Core\Convert;
 use SilverStripe\Dev\FunctionalTest;
 use SilverStripe\Forms\DropdownField;
@@ -33,6 +34,12 @@ class UserDefinedFormTest extends FunctionalTest
     protected static $required_extensions = [
         UserDefinedForm::class => [UserFormFieldEditorExtension::class],
     ];
+
+    protected function setUp()
+    {
+        parent::setUp();
+        Email::config()->update('admin_email', 'no-reply@example.com');
+    }
 
     public function testRollbackToVersion()
     {
@@ -70,10 +77,10 @@ class UserDefinedFormTest extends FunctionalTest
 
         $fields = $form->getCMSFields();
 
-        $this->assertTrue($fields->dataFieldByName('Fields') !== null);
-        $this->assertTrue($fields->dataFieldByName('EmailRecipients') != null);
-        $this->assertTrue($fields->dataFieldByName('Submissions') != null);
-        $this->assertTrue($fields->dataFieldByName('OnCompleteMessage') != null);
+        $this->assertNotNull($fields->dataFieldByName('Fields'));
+        $this->assertNotNull($fields->dataFieldByName('EmailRecipients'));
+        $this->assertNotNull($fields->dataFieldByName('Submissions'));
+        $this->assertNotNull($fields->dataFieldByName('OnCompleteMessage'));
     }
 
 
@@ -107,12 +114,12 @@ class UserDefinedFormTest extends FunctionalTest
 
         $fields = $popup->getCMSFields();
 
-        $this->assertTrue($fields->dataFieldByName('EmailSubject') !== null);
-        $this->assertTrue($fields->dataFieldByName('EmailFrom') !== null);
-        $this->assertTrue($fields->dataFieldByName('EmailAddress') !== null);
-        $this->assertTrue($fields->dataFieldByName('HideFormData') !== null);
-        $this->assertTrue($fields->dataFieldByName('SendPlain') !== null);
-        $this->assertTrue($fields->dataFieldByName('EmailBody') !== null);
+        $this->assertNotNull($fields->dataFieldByName('EmailSubject'));
+        $this->assertNotNull($fields->dataFieldByName('EmailFrom'));
+        $this->assertNotNull($fields->dataFieldByName('EmailAddress'));
+        $this->assertNotNull($fields->dataFieldByName('HideFormData'));
+        $this->assertNotNull($fields->dataFieldByName('SendPlain'));
+        $this->assertNotNull($fields->dataFieldByName('EmailBody'));
 
         // add an email field, it should now add a or from X address picker
         $email = $this->objFromFixture(EditableEmailField::class, 'email-field');


### PR DESCRIPTION
Fixes #711 by introducing two things:

- adds `EmailRecipient` fields to the form's `requiredFields` if no fallback is defined.
- prefers the dynamic fields over the string fields, and uses them only as a fallback