### PR TITLE
Add PHP 7.2 to Travis build matrix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,9 @@ matrix:
     - php: 7.0
       env: DB=MYSQL RECIPE_VERSION=1.1.x-dev PHPUNIT_TEST=1
     - php: 7.1
-      env: DB=MYSQL RECIPE_VERSION=1.x-dev PHPUNIT_COVERAGE_TEST=1
+      env: DB=MYSQL RECIPE_VERSION=1.2.x-dev PHPUNIT_COVERAGE_TEST=1
+    - php: 7.2
+      env: DB=MYSQL RECIPE_VERSION=1.x-dev PHPUNIT_TEST=1
 
 before_script:
   # Init PHP


### PR DESCRIPTION
Build failures noted by @NightJar in CMS recipe 1.1.0 and later due to custom relation duplication logic being combined with $owns duplication introduced in SS 4.1