### PR TITLE
API Remove use of getEscapedTitle() and deprecated for future removal. Use $Title directly instead.

### DIFF
--- a/code/Model/EditableFormField.php
+++ b/code/Model/EditableFormField.php
@@ -635,6 +635,8 @@ class EditableFormField extends DataObject
     /**
      * Returns the Title for rendering in the front-end (with XML values escaped)
      *
+     * @deprecated 5.0..6.0 XML is automatically escaped in templates from SS 4 onwards. Please use $Title directly.
+     *
      * @return string
      */
     public function getEscapedTitle()

--- a/code/Model/EditableFormField/EditableCheckbox.php
+++ b/code/Model/EditableFormField/EditableCheckbox.php
@@ -44,7 +44,7 @@ class EditableCheckbox extends EditableFormField
 
     public function getFormField()
     {
-        $field = CheckboxField::create($this->Name, $this->EscapedTitle, $this->CheckedDefault)
+        $field = CheckboxField::create($this->Name, $this->Title, $this->CheckedDefault)
             ->setFieldHolderTemplate(__CLASS__ . '_holder')
             ->setTemplate(__CLASS__);
 

--- a/code/Model/EditableFormField/EditableCheckboxGroupField.php
+++ b/code/Model/EditableFormField/EditableCheckboxGroupField.php
@@ -25,7 +25,7 @@ class EditableCheckboxGroupField extends EditableMultipleOptionField
 
     public function getFormField()
     {
-        $field = UserFormsCheckboxSetField::create($this->Name, $this->EscapedTitle, $this->getOptionsMap())
+        $field = UserFormsCheckboxSetField::create($this->Name, $this->Title, $this->getOptionsMap())
             ->setFieldHolderTemplate(EditableMultipleOptionField::class . '_holder')
             ->setTemplate(UserFormsCheckboxSetField::class);
 

--- a/code/Model/EditableFormField/EditableCountryDropdownField.php
+++ b/code/Model/EditableFormField/EditableCountryDropdownField.php
@@ -35,7 +35,7 @@ class EditableCountryDropdownField extends EditableFormField
 
     public function getFormField()
     {
-        $field = DropdownField::create($this->Name, $this->EscapedTitle)
+        $field = DropdownField::create($this->Name, $this->Title)
             ->setSource(i18n::getData()->getCountries())
             ->setFieldHolderTemplate(EditableFormField::class . '_holder')
             ->setTemplate(EditableDropdown::class);

--- a/code/Model/EditableFormField/EditableDateField.php
+++ b/code/Model/EditableFormField/EditableDateField.php
@@ -58,8 +58,8 @@ class EditableDateField extends EditableFormField
             ? DBDatetime::now()->Format('Y-m-d')
             : $this->Default;
 
-        $field = FormField::create($this->Name, $this->EscapedTitle, $defaultValue)
-            ->setFieldHolderTemplate('UserFormsField_holder')
+        $field = FormField::create($this->Name, $this->Title, $defaultValue)
+            ->setFieldHolderTemplate(EditableFormField::class . '_holder')
             ->setTemplate(EditableFormField::class);
 
         $this->doUpdateFormField($field);

--- a/code/Model/EditableFormField/EditableDropdown.php
+++ b/code/Model/EditableFormField/EditableDropdown.php
@@ -60,7 +60,7 @@ class EditableDropdown extends EditableMultipleOptionField
      */
     public function getFormField()
     {
-        $field = DropdownField::create($this->Name, $this->EscapedTitle, $this->getOptionsMap())
+        $field = DropdownField::create($this->Name, $this->Title, $this->getOptionsMap())
             ->setFieldHolderTemplate(EditableFormField::class . '_holder')
             ->setTemplate(__CLASS__);
 

--- a/code/Model/EditableFormField/EditableEmailField.php
+++ b/code/Model/EditableFormField/EditableEmailField.php
@@ -30,8 +30,8 @@ class EditableEmailField extends EditableFormField
 
     public function getFormField()
     {
-        $field = EmailField::create($this->Name, $this->EscapedTitle, $this->Default)
-            ->setFieldHolderTemplate('UserFormsField_holder')
+        $field = EmailField::create($this->Name, $this->Title, $this->Default)
+            ->setFieldHolderTemplate(EditableFormField::class . '_holder')
             ->setTemplate(EditableFormField::class);
 
         $this->doUpdateFormField($field);

--- a/code/Model/EditableFormField/EditableFieldGroup.php
+++ b/code/Model/EditableFormField/EditableFieldGroup.php
@@ -74,7 +74,7 @@ class EditableFieldGroup extends EditableFormField
     public function getFormField()
     {
         $field = UserFormsGroupField::create()
-            ->setTitle($this->EscapedTitle ?: false)
+            ->setTitle($this->Title ?: false)
             ->setName($this->Name);
         $this->doUpdateFormField($field);
         return $field;

--- a/code/Model/EditableFormField/EditableFileField.php
+++ b/code/Model/EditableFormField/EditableFileField.php
@@ -97,11 +97,11 @@ class EditableFileField extends EditableFormField
 
     public function getFormField()
     {
-        $field = FileField::create($this->Name, $this->EscapedTitle)
-            ->setFieldHolderTemplate('UserFormsField_holder')
+        $field = FileField::create($this->Name, $this->Title)
+            ->setFieldHolderTemplate(EditableFormField::class . '_holder')
             ->setTemplate(__CLASS__);
 
-        $field->setFieldHolderTemplate('UserFormsField_holder')
+        $field->setFieldHolderTemplate(EditableFormField::class . '_holder')
             ->setTemplate(__CLASS__);
 
         $field->getValidator()->setAllowedExtensions(

--- a/code/Model/EditableFormField/EditableFormHeading.php
+++ b/code/Model/EditableFormField/EditableFormHeading.php
@@ -68,7 +68,7 @@ class EditableFormHeading extends EditableFormField
 
     public function getFormField()
     {
-        $labelField = HeaderField::create('userforms-header', $this->EscapedTitle)
+        $labelField = HeaderField::create('userforms-header', $this->Title)
             ->setHeadingLevel($this->Level);
         $labelField->addExtraClass('FormHeading');
         $labelField->setAttribute('data-id', $this->Name);
@@ -80,8 +80,7 @@ class EditableFormHeading extends EditableFormField
     {
         // set the right title on this field
         if ($this->RightTitle) {
-            // Since this field expects raw html, safely escape the user data prior
-            $field->setRightTitle(Convert::raw2xml($this->RightTitle));
+            $field->setRightTitle($this->RightTitle);
         }
 
         // if this field has an extra class

--- a/code/Model/EditableFormField/EditableFormStep.php
+++ b/code/Model/EditableFormField/EditableFormStep.php
@@ -46,7 +46,7 @@ class EditableFormStep extends EditableFormField
     {
         $field = UserFormsStepField::create()
             ->setName($this->Name)
-            ->setTitle($this->EscapedTitle);
+            ->setTitle($this->Title);
         $this->doUpdateFormField($field);
         return $field;
     }

--- a/code/Model/EditableFormField/EditableMemberListField.php
+++ b/code/Model/EditableFormField/EditableMemberListField.php
@@ -54,7 +54,7 @@ class EditableMemberListField extends EditableFormField
         }
 
         $members = Member::map_in_groups($this->GroupID);
-        $field = DropdownField::create($this->Name, $this->EscapedTitle, $members);
+        $field = DropdownField::create($this->Name, $this->Title, $members);
         $this->doUpdateFormField($field);
         return $field;
     }

--- a/code/Model/EditableFormField/EditableNumericField.php
+++ b/code/Model/EditableFormField/EditableNumericField.php
@@ -41,7 +41,7 @@ class EditableNumericField extends EditableFormField
      */
     public function getFormField()
     {
-        $field = NumericField::create($this->Name, $this->EscapedTitle, $this->Default)
+        $field = NumericField::create($this->Name, $this->Title, $this->Default)
             ->setFieldHolderTemplate(EditableFormField::class . '_holder')
             ->setTemplate(EditableFormField::class)
             ->addExtraClass('number');

--- a/code/Model/EditableFormField/EditableOption.php
+++ b/code/Model/EditableFormField/EditableOption.php
@@ -2,11 +2,8 @@
 
 namespace SilverStripe\UserForms\Model\EditableFormField;
 
-use SilverStripe\CMS\Controllers\CMSMain;
-use SilverStripe\Control\Controller;
 use SilverStripe\Core\Convert;
 use SilverStripe\ORM\DataObject;
-use SilverStripe\UserForms\Model\EditableFormField\EditableMultipleOptionField;
 use SilverStripe\Versioned\Versioned;
 
 /**
@@ -66,12 +63,12 @@ class EditableOption extends DataObject
     }
 
     /**
-     * @deprecated 5.0 Use "$Title.XML" in templates instead
+     * @deprecated 5.0..6.0 Use "$Title" in templates instead
      * @return string
      */
     public function getEscapedTitle()
     {
-        return Convert::raw2att($this->Title);
+        return Convert::raw2xml($this->Title);
     }
 
     /**

--- a/code/Model/EditableFormField/EditableRadioField.php
+++ b/code/Model/EditableFormField/EditableRadioField.php
@@ -35,7 +35,7 @@ class EditableRadioField extends EditableMultipleOptionField
 
     public function getFormField()
     {
-        $field = OptionsetField::create($this->Name, $this->EscapedTitle, $this->getOptionsMap())
+        $field = OptionsetField::create($this->Name, $this->Title, $this->getOptionsMap())
             ->setFieldHolderTemplate(EditableMultipleOptionField::class . '_holder')
             ->setTemplate('SilverStripe\\UserForms\\FormField\\UserFormsOptionSetField');
 

--- a/code/Model/EditableFormField/EditableTextField.php
+++ b/code/Model/EditableFormField/EditableTextField.php
@@ -128,12 +128,12 @@ class EditableTextField extends EditableFormField
     public function getFormField()
     {
         if ($this->Rows > 1) {
-            $field = TextareaField::create($this->Name, $this->EscapedTitle, $this->Default)
+            $field = TextareaField::create($this->Name, $this->Title, $this->Default)
                 ->setFieldHolderTemplate(EditableFormField::class . '_holder')
                 ->setTemplate(str_replace('EditableTextField', 'EditableTextareaField', __CLASS__))
                 ->setRows($this->Rows);
         } else {
-            $field = TextField::create($this->Name, $this->EscapedTitle, $this->Default)
+            $field = TextField::create($this->Name, $this->Title, $this->Default)
                 ->setFieldHolderTemplate(EditableFormField::class . '_holder')
                 ->setTemplate(EditableFormField::class);
         }


### PR DESCRIPTION
Templates escape by default, so this method is redundant.

Fixes an issue such as the double escaped label as seen in https://github.com/silverstripe/cwp-starter-theme/issues/33