### PR TITLE
FIX Correctly return the max file size in MB

### DIFF
--- a/code/Model/EditableFormField/EditableFileField.php
+++ b/code/Model/EditableFormField/EditableFileField.php
@@ -159,6 +159,6 @@ class EditableFileField extends EditableFormField
 
     public function getPHPMaxFileSizeMB()
     {
-        return round(static::get_php_max_file_size() / 1024.0, 1);
+        return round(static::get_php_max_file_size() / 1024 / 1024, 1);
     }
 }


### PR DESCRIPTION
No unit test on account of being unable to mock the static `get_php_max_file_size` method - ideally it wouldn't be static (it doesn't need to be anyway), but I can't change that without breaking semver.

Resolves #738