### PR TITLE
FIX use the same translation variable key as core

### DIFF
--- a/code/Model/EditableFormField.php
+++ b/code/Model/EditableFormField.php
@@ -806,7 +806,7 @@ class EditableFormField extends DataObject
     public function getErrorMessage()
     {
         $title = strip_tags("'". ($this->Title ? $this->Title : $this->Name) . "'");
-        $standard = _t('SilverStripe\\Forms\\Form.FIELDISREQUIRED', '{field} is required.', ['field' => $title]);
+        $standard = _t('SilverStripe\\Forms\\Form.FIELDISREQUIRED', '{name} is required.', ['name' => $title]);
 
         // only use CustomErrorMessage if it has a non empty value
         $errorMessage = (!empty($this->CustomErrorMessage)) ? $this->CustomErrorMessage : $standard;

--- a/lang/en.yml
+++ b/lang/en.yml
@@ -22,7 +22,7 @@ en:
     PLURALNAME: Pages
     SINGULARNAME: Page
   SilverStripe\Forms\Form:
-    FIELDISREQUIRED: '{field} is required'
+    FIELDISREQUIRED: '{name} is required'
   SilverStripe\Forms\GridField\GridField:
     Filter: Filter
     ResetFilter: Reset


### PR DESCRIPTION
This way when this translation string overrides the core one, the core
triggered translations will still continue working.