### PR TITLE
fix(SubmittedFormField): Fix bug where FormattedValue isn't cast to HTMLFragment

### DIFF
--- a/code/Model/Submission/SubmittedFormField.php
+++ b/code/Model/Submission/SubmittedFormField.php
@@ -27,6 +27,10 @@ class SubmittedFormField extends DataObject
         'FormattedValue' => 'Value'
     ];
 
+    private static $casting = [
+        'FormattedValue' => 'HTMLFragment'
+    ];
+
     private static $table_name = 'SubmittedFormField';
 
     /**


### PR DESCRIPTION
fix(SubmittedFormField): Fix bug where FormattedValue isn't cast to HTMLFragment, which causes <br/> to appear in Email templates.

Data submitted by a user on EditableTextField with multiple rows needs this.

Just incase anybody is curious, this does **NOT** fix the following issue:
https://github.com/silverstripe/silverstripe-userforms/issues/633
