### PR TITLE
Use valid EmailFrom Fields instead of multiselectors

### DIFF
--- a/code/Model/Recipient/EmailRecipient.php
+++ b/code/Model/Recipient/EmailRecipient.php
@@ -723,7 +723,7 @@ class EmailRecipient extends DataObject
             return $validEmailToFields;
         } else {
             // To address cannot be unbound, so restrict to pre-defined lists
-            return $this->getMultiOptionFields();
+            return $this->getValidEmailFromFields();
         }
     }
 


### PR DESCRIPTION
The list is populated with radio-fields and checkbox-fields, which do not allow for entering an email address