### PR TITLE
FIX Submitted form field values are no longer double escaped in the CMS

### DIFF
--- a/code/Model/Submission/SubmittedFormField.php
+++ b/code/Model/Submission/SubmittedFormField.php
@@ -3,7 +3,9 @@
 namespace SilverStripe\UserForms\Model\Submission;
 
 use SilverStripe\ORM\DataObject;
-use SilverStripe\UserForms\Model\Submission\SubmittedForm;
+use SilverStripe\ORM\FieldType\DBField;
+use SilverStripe\Security\Member;
+use SilverStripe\UserForms\Model\EditableFormField;
 
 /**
  * Data received from a UserDefinedForm submission
@@ -25,10 +27,6 @@ class SubmittedFormField extends DataObject
     private static $summary_fields = [
         'Title' => 'Title',
         'FormattedValue' => 'Value'
-    ];
-
-    private static $casting = [
-        'FormattedValue' => 'HTMLFragment'
     ];
 
     private static $table_name = 'SubmittedFormField';
@@ -76,20 +74,20 @@ class SubmittedFormField extends DataObject
     /**
      * Generate a formatted value for the reports and email notifications.
      * Converts new lines (which are stored in the database text field) as
-     * <brs> so they will output as newlines in the reports
+     * <brs> so they will output as newlines in the reports.
      *
-     * @return string
+     * @return DBField
      */
     public function getFormattedValue()
     {
-        return nl2br($this->dbObject('Value')->ATT());
+        return $this->dbObject('Value');
     }
 
     /**
      * Return the value of this submitted form field suitable for inclusion
      * into the CSV
      *
-     * @return Text
+     * @return DBField
      */
     public function getExportValue()
     {


### PR DESCRIPTION
Recently #769 was merged which casts the output of getFormattedValue as an HTMLFragment (no encoding here), this results in double encoding of submitted form field values which contain HTML when viewing in the CMS and print views, because the `getFormattedValue` method escapes the content before passing it through `nl2br`. `GridFieldDataColumns::castValue` then escapes it again.

This change removes the underlying escaping and allows the SilverStripe template engine to cast by default as escaped text. This also naturally handles new line processing.

Related pull request for double escaping in GridField print views: https://github.com/silverstripe/silverstripe-framework/pull/8326

### Expectation

All four areas: CMS detail view, GridField print view, submission emails and CSV exports should all safely escape HTML in submitted form field values, but not double escape them so they're still legible.

Example:

```diff
- &lt;p&gt;Hello world&lt;/p&gt;
+ <p>Hello world</p>
```

As well as this, the `<br>` tags that userforms was adding from `nl2br` were all being shown in the CSV exports and cluttering up the export values. This should be fixed too, they should not be shown in CSVs.

Note that @tardinha has suggested that he'd like all HTML stripped entirely from CSVs. I've stated that I disagree on the basis of that being too opinionated for the module itself, but that it could be done in user code instead.

### Tested

* CMS detail view ✅ 
* GridField print view ✅ (requires https://github.com/silverstripe/silverstripe-framework/pull/8326 first)
* Submission emails ✅ 
* Individual submission CSV exports ✅ 
* List of all submissions CSV exports ❌ 

### Remaining:

* The Submissions tab list in pages escapes all HTML in submitted form field values when exporting from the GridField (todo)

### Notes

Technically speaking this is a semver violation, I'm OK with it because DBFields can still be treated like a string (in terms of `echo $dbField` working) so I've made the PR anyway (until someone else complains enough) - noting this for brevity though.

Resolves #633