### PR TITLE
FIX Do not override core translation for 'field is required'

### DIFF
--- a/code/Model/EditableFormField.php
+++ b/code/Model/EditableFormField.php
@@ -27,6 +27,7 @@ use SilverStripe\ORM\ArrayList;
 use SilverStripe\ORM\DataObject;
 use SilverStripe\ORM\DB;
 use SilverStripe\ORM\FieldType\DBField;
+use SilverStripe\ORM\FieldType\DBVarchar;
 use SilverStripe\ORM\ValidationException;
 use SilverStripe\UserForms\Extension\UserFormFieldEditorExtension;
 use SilverStripe\UserForms\Model\EditableFormField\EditableFieldGroup;
@@ -801,12 +802,12 @@ class EditableFormField extends DataObject
      * Return the error message for this field. Either uses the custom
      * one (if provided) or the default SilverStripe message
      *
-     * @return Varchar
+     * @return DBVarchar
      */
     public function getErrorMessage()
     {
         $title = strip_tags("'". ($this->Title ? $this->Title : $this->Name) . "'");
-        $standard = _t('SilverStripe\\Forms\\Form.FIELDISREQUIRED', '{name} is required.', ['name' => $title]);
+        $standard = _t(__CLASS__ . '.FIELDISREQUIRED', '{name} is required', ['name' => $title]);
 
         // only use CustomErrorMessage if it has a non empty value
         $errorMessage = (!empty($this->CustomErrorMessage)) ? $this->CustomErrorMessage : $standard;

--- a/lang/en.yml
+++ b/lang/en.yml
@@ -3,8 +3,6 @@ en:
     SELECTUPLOADFOLDER: 'Select upload folder'
   SilverStripe\CMS\Model\SiteTree:
     TABMAIN: Main
-  SilverStripe\Forms\Form:
-    FIELDISREQUIRED: '{name} is required.'
   SilverStripe\UserForms:
     ADDEMAILRECIPIENT: 'Add Email Recipient'
     CLEARBUTTON: Clear
@@ -57,6 +55,7 @@ en:
     EXTRACLASS_SELECT: 'Select from the list of allowed styles'
     EXTRACLASS_TITLE: 'Extra Styling/Layout'
     EXTRACLASS_Title: 'Extra CSS classes'
+    FIELDISREQUIRED: '{name} is required'
     GROUP: Group
     INITIALVISIBILITY: 'Initial visibility'
     MERGEFIELDNAME: 'Merge field'


### PR DESCRIPTION
Fixes test failures in https://travis-ci.org/silverstripe/cwp-recipe-kitchen-sink/jobs/423801717

We can't use translations in other modules without them being overridden in this module, so I've updated the class name to be one that belongs to userforms.