### PR TITLE
FIX Do not remap polymorphic class names to UserDefinedForm if they are already an instance of it

### DIFF
--- a/code/Extension/UpgradePolymorphicExtension.php
+++ b/code/Extension/UpgradePolymorphicExtension.php
@@ -71,6 +71,11 @@ class UpgradePolymorphicExtension extends DataExtension
                         continue;
                     }
 
+                    // Don't rewrite class values when an existing value is set and is an instance of UserDefinedForm
+                    if ($relationshipObject instanceof UserDefinedForm) {
+                        continue;
+                    }
+
                     $entry->$fieldName = $this->defaultReplacement;
                     try {
                         $entry->write();


### PR DESCRIPTION
If the existing value is an instance of UserDefinedForm, don't rewrite it to UserDefinedForm.

Fixes https://github.com/silverstripe/silverstripe-userforms/issues/804

Needs to be merged up after merge