### PR TITLE
GridfiedExtensions PHP 7.2 compatibility

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -32,7 +32,7 @@
     "require": {
         "silverstripe/framework": "^3.4.2",
         "silverstripe/cms": "^3.4.2",
-        "symbiote/silverstripe-gridfieldextensions": "^2.0",
+        "symbiote/silverstripe-gridfieldextensions": "2.x-dev",
         "silverstripe/segment-field": "^1.0"
     },
     "suggest": {


### PR DESCRIPTION
GridfiedExtensions ist PHP 7.2 compatible in 2.x-dev Version (SS_Object instead of Object)
