### PR TITLE
Fix EdtiableDateField DefaultToToday using minute instead of month

### DIFF
--- a/code/Model/EditableFormField/EditableDateField.php
+++ b/code/Model/EditableFormField/EditableDateField.php
@@ -55,7 +55,7 @@ class EditableDateField extends EditableFormField
     public function getFormField()
     {
         $defaultValue = $this->DefaultToToday
-            ? DBDatetime::now()->Format('Y-m-d')
+            ? DBDatetime::now()->Format('yyyy-MM-dd')
             : $this->Default;
 
         $field = FormField::create($this->Name, $this->Title ?: false, $defaultValue)


### PR DESCRIPTION
Fixes incorrectly using the minute (m) instead of the month (M) and switches to using an ISO-8601 style date (e.g 2018-09-21)

Date format strings were taken from the link provided in DBDatetime: http://userguide.icu-project.org/formatparse/datetime