### PR TITLE
Prevent eslint rules from cascading.

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -1,5 +1,6 @@
 {
   "extends": "airbnb",
+  "root": true,
   "rules": {
     "init-declarations": 1
   }


### PR DESCRIPTION
This prevents `eslint` rules from cascading to the parent directory and fixes #819.