### PR TITLE
Submissions don't make sessions

### DIFF
--- a/code/Control/UserDefinedFormController.php
+++ b/code/Control/UserDefinedFormController.php
@@ -410,7 +410,7 @@ JS
             }
         }
 
-        if (!$this->DisableSaveSubmissions) {
+        if (!$this->DisableSaveSubmissions && !$this->DisableSaveSubmissionSession) {
             $session->set('userformssubmission'. $this->ID, $submittedForm->ID);
         }
 

--- a/code/UserForm.php
+++ b/code/UserForm.php
@@ -97,6 +97,7 @@ trait UserForm
         'OnCompleteMessage' => 'HTMLText',
         'ShowClearButton' => 'Boolean',
         'DisableSaveSubmissions' => 'Boolean',
+        'DisableSaveSubmissionSession' => 'Boolean',
         'EnableLiveValidation' => 'Boolean',
         'DisplayErrorMessagesAtTop' => 'Boolean',
         'DisableAuthenicatedFinishAction' => 'Boolean',
@@ -109,6 +110,7 @@ trait UserForm
     private static $defaults = [
         'Content' => '$UserDefinedForm',
         'DisableSaveSubmissions' => 0,
+        'DisableSaveSubmissionSession' => 0,
         'OnCompleteMessage' => '<p>Thanks, we\'ve received your submission.</p>'
     ];
 
@@ -315,6 +317,14 @@ SQL;
                 CheckboxField::create(
                     'DisableSaveSubmissions',
                     _t(__CLASS__.'.SAVESUBMISSIONS', 'Disable Saving Submissions to Server')
+                )
+            );
+
+            $fields->addFieldToTab(
+                'Root.FormOptions',
+                CheckboxField::create(
+                    'DisableSaveSubmissionSession',
+                    _t(__CLASS__.'.SAVESUBMISSIONSESSION', 'Disable Saving Submission references in a Session')
                 )
             );
         });

--- a/lang/en_US.yml
+++ b/lang/en_US.yml
@@ -27,6 +27,7 @@ en_US:
     ORSELECTAFIELDTOUSEASTO: '.. or select a field to use as the to address'
     REPLYADDRESS: 'Email for reply to'
     SAVESUBMISSIONS: 'Disable Saving Submissions to Server'
+    SAVESUBMISSIONSESSION: 'Disable Saving Submission references in a Session'
     SENDEMAILTO: 'Send email to'
     SENDPLAIN: 'Send email as plain text? (HTML will be stripped)'
     SHOWCLEARFORM: 'Show Clear Form Button'


### PR DESCRIPTION
Ran into an edge case where I didn't want userforms to create sessions for a user when they submit the form.

The only way to do this was to either copy past the whole process function and edit it, not save the submissions any where, or hook into `updateEmailData` all of which felt like work arounds.

This is an edge case so I'm not 100% sure we'd want it in the admin but on the off chance we do I've done it like this. Other options would be looking at making it a yml config setting or offering and extend closer to the point for various other edgecases too.

