### PR TITLE
FIX app email templates not resolving correctly

### DIFF
--- a/code/Model/Recipient/EmailRecipient.php
+++ b/code/Model/Recipient/EmailRecipient.php
@@ -506,8 +506,8 @@ class EmailRecipient extends DataObject
             $templatePath = substr($absoluteFilename, strlen($prefixToStrip) + 1);
 
             // Optionally remove "templates/" prefixes
-            if (substr($templatePath, 0, 10)) {
-                $templatePath = substr($templatePath, 10);
+            if (preg_match('/(?<=templates\/).*$/', $templatePath, $matches)) {
+                $templatePath = $matches[0];
             }
 
             $templates[$templatePath] = $template['filename'];


### PR DESCRIPTION
Ran into an issues overriding `$email_template_directory` with `app/templates/email` where EmailRecipient tried to resolve the template directory as `tes/email` because of this bit of code which cuts the first 10 characters off the template path. Changed this to use regex to keep everything after `templates/`.