### PR TITLE
PATCH: Fixing escape error in required identifier

### DIFF
--- a/code/Model/EditableFormField.php
+++ b/code/Model/EditableFormField.php
@@ -754,7 +754,7 @@ class EditableFormField extends DataObject
 
             if ($identifier = UserDefinedForm::config()->required_identifier) {
                 $title = $field->Title() . " <span class='required-identifier'>". $identifier . "</span>";
-                $field->setTitle($title);
+                $field->setTitle(DBField::create_field('HTMLText', $title));
             }
         }
 


### PR DESCRIPTION
Without the change the required identifier shows up like this:
![image](https://user-images.githubusercontent.com/167154/50959902-ee283b80-1528-11e9-8c1b-a377dea03ea7.png)
