### PR TITLE
Allow form fields in email subjects

### DIFF
--- a/code/Control/UserDefinedFormController.php
+++ b/code/Control/UserDefinedFormController.php
@@ -364,10 +364,10 @@ JS
                     if ($submittedFormField && trim($submittedFormField->Value)) {
                         $email->setSubject($submittedFormField->Value);
                     } else {
-                        $email->setSubject($recipient->EmailSubject);
+                        $email->setSubject(SSViewer::execute_string($recipient->EmailSubject, $mergeFields));
                     }
                 } else {
-                    $email->setSubject($recipient->EmailSubject);
+                    $email->setSubject(SSViewer::execute_string($recipient->EmailSubject, $mergeFields));
                 }
 
                 $this->extend('updateEmail', $email, $recipient, $emailData);

--- a/tests/Model/EditableFormFieldTest.yml
+++ b/tests/Model/EditableFormFieldTest.yml
@@ -1,10 +1,10 @@
 SilverStripe\UserForms\Model\EditableFormField\EditableTextField:
   basic-text:
-    Name: basic-text-name
+    Name: basic_text_name
     Title: Basic Text Field
 
   basic-text-2:
-    Name: basic-text-name
+    Name: basic_text_name
     Title: Basic Text Field
 
   required-text:

--- a/tests/UserFormsTest.yml
+++ b/tests/UserFormsTest.yml
@@ -63,11 +63,11 @@ SilverStripe\UserForms\Model\EditableFormField\EditableOption:
 
 SilverStripe\UserForms\Model\EditableFormField\EditableTextField:
   basic-text:
-    Name: basic-text-name
+    Name: basic_text_name
     Title: Basic Text Field
 
   basic-text-2:
-    Name: basic-text-name
+    Name: basic_text_name
     Title: Basic Text Field
 
   your-name-field:


### PR DESCRIPTION
Allows form fields in email subjects using merge field the same as body insertion functionality.

As requested in issue #442 