### PR TITLE
BUGFIX: re-added can* methods for EditableOption field

### DIFF
--- a/code/Model/EditableFormField/EditableOption.php
+++ b/code/Model/EditableFormField/EditableOption.php
@@ -2,7 +2,6 @@
 
 namespace SilverStripe\UserForms\Model\EditableFormField;
 
-use SilverStripe\Control\Controller;
 use SilverStripe\Core\Convert;
 use SilverStripe\ORM\DataObject;
 use SilverStripe\Security\Member;
@@ -134,11 +133,12 @@ class EditableOption extends DataObject
      */
     public function canCreate($member = null, $context = [])
     {
-        // Check parent page
-        $parent = $this->getCanCreateContext(func_get_args());
+        // Check parent object
+        $parent = $this->Parent();
         if ($parent) {
-            return $parent->canEdit($member);
+            return $parent->canCreate($member);
         }
+
         // Fall back to secure admin permissions
         return parent::canCreate($member);
     }
@@ -158,25 +158,5 @@ class EditableOption extends DataObject
     public function canUnpublish($member = null)
     {
         return $this->canDelete($member);
-    }
-
-    /**
-     * Helper method to check the parent for this object
-     *
-     * @param array $args List of arguments passed to canCreate
-     * @return DataObject Some parent dataobject to inherit permissions from
-     */
-    protected function getCanCreateContext($args)
-    {
-        // Inspect second parameter to canCreate for a 'Parent' context
-        if (isset($args[1]['Parent'])) {
-            return $args[1]['Parent'];
-        }
-        // Hack in currently edited page if context is missing
-        if (Controller::has_curr() && Controller::curr() instanceof CMSMain) {
-            return Controller::curr()->currentPage();
-        }
-        // No page being edited
-        return null;
     }
 }


### PR DESCRIPTION
Non-admin users are unable to create/edit/delete `EditableOption` fields as `EditableOption` does not extend `EditableFormField` which is the class that contains all the `can*` methods by default. 

Therefore, this fix is to re-add the `can*` methods that were removed from `EditableOption` based on this commit https://github.com/silverstripe/silverstripe-userforms/commit/5c9417da215dcd8e9b1c50a42e0cc7da04ebd5ca#diff-203de929c7874eb98eb90d00b1f21793L73. 