### PR TITLE
Prevent 'undefined index' warnings with optional country dropdowns

### DIFF
--- a/code/Model/EditableFormField/EditableCountryDropdownField.php
+++ b/code/Model/EditableFormField/EditableCountryDropdownField.php
@@ -47,7 +47,7 @@ class EditableCountryDropdownField extends EditableFormField
 
     public function getValueFromData($data)
     {
-        if (isset($data[$this->Name])) {
+        if (isset($data[$this->Name]) && !empty($data[$this->Name])) {
             $source = $this->getFormField()->getSource();
             return $source[$data[$this->Name]];
         }

--- a/code/Model/EditableFormField/EditableCountryDropdownField.php
+++ b/code/Model/EditableFormField/EditableCountryDropdownField.php
@@ -47,7 +47,7 @@ class EditableCountryDropdownField extends EditableFormField
 
     public function getValueFromData($data)
     {
-        if (isset($data[$this->Name]) && !empty($data[$this->Name])) {
+        if (!empty($data[$this->Name])) {
             $source = $this->getFormField()->getSource();
             return $source[$data[$this->Name]];
         }


### PR DESCRIPTION
SilverStripe: `4.3.3`
User Forms: `5.3.2`

All dropdown fields have the option to have an 'empty default string' such as '- Please Select -', this is also true for Country Dropdown fields.

<img width="1154" alt="Screen Shot 2019-04-25 at 16 27 43" src="https://user-images.githubusercontent.com/5114645/56748177-47824680-6777-11e9-99da-a567b9db030e.png">

When this is enabled, the dropdown field is non-required and the user does not make any selection, the value submitted is '' (empty string).

The 'source' for `CountryDropdownField` contains only country data and even when an empty response is allowed for, there is nothing to abort the checking for the submitted value (and empty string) in the dropdown source. In this scenario, an undefined index warning is thrown:

<img width="1567" alt="Screen Shot 2019-04-25 at 16 47 10" src="https://user-images.githubusercontent.com/5114645/56749537-d42e0400-6779-11e9-913c-362d17b2552c.png">

Checking that the submitted data is not an 'empty' value prevents this.

An alternative approach would be to return an empty string should the index not exist e.g.:

```
return (isset($source[$data[$this->Name]])) ? $source[$data[$this->Name]] : '';
```
