### PR TITLE
FIX Support new arguments for better buttons support

### DIFF
--- a/code/Extension/UserFormFieldEditorExtension.php
+++ b/code/Extension/UserFormFieldEditorExtension.php
@@ -103,7 +103,7 @@ class UserFormFieldEditorExtension extends DataExtension
                 new GridFieldDeleteAction(),
                 new GridFieldToolbarHeader(),
                 new GridFieldOrderableRows('Sort'),
-                new GridFieldDetailForm()
+                new GridFieldDetailForm(null, false, false)
             );
 
         $editButton->removeExtraClass('grid-field__icon-action--hidden-on-hover');

--- a/code/UserForm.php
+++ b/code/UserForm.php
@@ -258,7 +258,7 @@ SQL;
             $config->addComponent(new GridFieldDeleteAction());
             $config->addComponent(new GridFieldPageCount('toolbar-header-right'));
             $config->addComponent($pagination = new GridFieldPaginator(25));
-            $config->addComponent(new GridFieldDetailForm());
+            $config->addComponent(new GridFieldDetailForm(null, null, false));
             $config->addComponent(new GridFieldButtonRow('after'));
             $config->addComponent($export = new GridFieldExportButton('buttons-after-left'));
             $config->addComponent($print = new GridFieldPrintButton('buttons-after-left'));


### PR DESCRIPTION
Fixes #878 

This removes all buttons from the form builder, and just the add button from submissions.

This is not a breaking change - constructor arguments are swallowed if not supported.