### PR TITLE
Add presence validation for EmailRecipient recipient, add error handling

### DIFF
--- a/code/Model/Recipient/EmailRecipient.php
+++ b/code/Model/Recipient/EmailRecipient.php
@@ -550,6 +550,12 @@ class EmailRecipient extends DataObject
         if (!$this->EmailFrom && empty(Email::getSendAllEmailsFrom()) && empty(Email::config()->get('admin_email'))) {
             $result->addError(_t(__CLASS__.".EMAILFROMREQUIRED", '"Email From" address is required'));
         }
+
+        // Sending will also fail if there's no recipient defined
+        if (!$this->EmailAddress && !$this->SendEmailToFieldID) {
+            $result->addError(_t(__CLASS__.".EMAILTOREQUIRED", '"Send email to" address or field is required'));
+        }
+
         return $result;
     }
 

--- a/tests/Model/Recipient/EmailRecipientTest.php
+++ b/tests/Model/Recipient/EmailRecipientTest.php
@@ -27,4 +27,15 @@ class EmailRecipientTest extends SapphireTest
         $result = $recipient->getEmailBodyContent();
         $this->assertContains('/about-us/', $result);
     }
+
+    /**
+     * @expectedException SilverStripe\ORM\ValidationException
+     * @expectedExceptionMessage "Send email to" address or field is required
+     */
+    public function testEmptyRecipientFailsValidation()
+    {
+        $recipient = new EmailRecipient();
+        $recipient->EmailFrom = 'test@example.com';
+        $recipient->write();
+    }
 }

--- a/tests/Model/UserDefinedFormTest.php
+++ b/tests/Model/UserDefinedFormTest.php
@@ -104,7 +104,6 @@ class UserDefinedFormTest extends FunctionalTest
         $this->assertNotContains('SummaryHide', array_keys($summaryFields), 'Summary field showing displayed field');
     }
 
-
     public function testEmailRecipientPopup()
     {
         $this->logInWithPermission('ADMIN');
@@ -114,6 +113,7 @@ class UserDefinedFormTest extends FunctionalTest
         $popup = new EmailRecipient();
         $popup->FormID = $form->ID;
         $popup->FormClass = UserDefinedForm::class;
+        $popup->EmailAddress = 'test@example.com';
 
         $fields = $popup->getCMSFields();
 
@@ -146,6 +146,7 @@ class UserDefinedFormTest extends FunctionalTest
     public function testGetEmailBodyContent()
     {
         $recipient = new EmailRecipient();
+        $recipient->EmailAddress = 'test@example.com';
 
         $emailBody = 'not html';
         $emailBodyHtml = '<p>html</p>';
@@ -185,6 +186,7 @@ class UserDefinedFormTest extends FunctionalTest
         $recipient = new EmailRecipient();
         $recipient->FormID = $page->ID;
         $recipient->FormClass = UserDefinedForm::class;
+        $recipient->EmailAddress = 'test@example.com';
 
         // Set the default template
         $recipient->EmailTemplate = current(array_keys($recipient->getEmailTemplateDropdownValues()));


### PR DESCRIPTION
This PR:

- Adds a basic validation check to ensure either an EmailAddress or a field to pull the address from are set on EmailRecipients
- Adds some error handling around setting the recipient during submission, in case the address isn't present or is invalid

Resolves #711.