### PR TITLE
Use config to defined controller name on UserDefinedForm

### DIFF
--- a/code/Model/UserDefinedForm.php
+++ b/code/Model/UserDefinedForm.php
@@ -31,6 +31,6 @@ class UserDefinedForm extends Page
 
     /**
      * @var string
-    */
+     */
     private static $controller_name = UserDefinedFormController::class;
 }

--- a/code/Model/UserDefinedForm.php
+++ b/code/Model/UserDefinedForm.php
@@ -29,8 +29,8 @@ class UserDefinedForm extends Page
      */
     private static $table_name = 'UserDefinedForm';
 
-    public function getControllerName()
-    {
-        return UserDefinedFormController::class;
-    }
+    /**
+     * @var string
+    */
+    private static $controller_name = UserDefinedFormController::class;
 }


### PR DESCRIPTION
This allows any subclass of UserDefinedForm to define their own controller without having to overwrite the gteControllerName() method.