### PR TITLE
Fixed missing searchable_fields list for EditableFormFields

### DIFF
--- a/code/Model/EditableFormField.php
+++ b/code/Model/EditableFormField.php
@@ -117,6 +117,13 @@ class EditableFormField extends DataObject
     ];
 
     /**
+     * @var array
+     */
+    private static $searchable_fields = [
+        'Title',
+    ];
+
+    /**
      * @config
      * @var array
      */


### PR DESCRIPTION
In SS4.2, when an `EditableFormField` is used in the context of a `GridField` the `GridField` expects the `EditableFormField` to have a list of `searchable_fields` by default so it can create generic search functionality.

This currently does not exist in `EditableFormField` which means any class that uses `EditableFormField` in a `GridField` context will receive an error message along the lines of: `Call to a member function scaffoldSearchField() on string ` 