### PR TITLE
FIX Ensure initial visibility on fields is respected on hidden form steps

### DIFF
--- a/code/model/UserDefinedForm.php
+++ b/code/model/UserDefinedForm.php
@@ -782,7 +782,9 @@ JS
             {$holder}.{$rule['opposite']}.trigger('{$rule['holder_event_opposite']}');
         }
     });
-    $("{$target}").find('.hide').removeClass('hide');
+    if (!$("{$target}").hasClass('form-step')) {
+        $("{$target}").find('.hide').removeClass('hide');
+    }
 EOS;
         }
 


### PR DESCRIPTION
Currently if steps have the initial visibility of 'hide' then any fields inside that step are shown initially, even if their own initial visibility is set to hide.