### PR TITLE
fix(submitted-form): canCreate not checking parent

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,7 @@
 language: php
 
+dist: trusty
+
 env:
   global:
     - COMPOSER_ROOT_VERSION=5.0.x-dev

--- a/code/Model/Submission/SubmittedForm.php
+++ b/code/Model/Submission/SubmittedForm.php
@@ -132,10 +132,10 @@ class SubmittedForm extends DataObject
         }
 
         if ($this->Parent()) {
-            return $this->Parent()->canCreate();
+            return $this->Parent()->canCreate($member);
         }
 
-        return parent::canCreate();
+        return parent::canCreate($member);
     }
 
     /**

--- a/code/Model/Submission/SubmittedForm.php
+++ b/code/Model/Submission/SubmittedForm.php
@@ -130,7 +130,12 @@ class SubmittedForm extends DataObject
         if ($extended !== null) {
             return $extended;
         }
-        return $this->Parent()->canCreate();
+
+        if ($this->Parent()) {
+            return $this->Parent()->canCreate();
+        }
+
+        return parent::canCreate();
     }
 
     /**


### PR DESCRIPTION
Fixes #903 

I wasn't sure whether to pass `$member` as an argument or not, so I stuck with how it was before. I can change that if need be.