### PR TITLE
Allow Injector to replace UserDefinedForm class

### DIFF
--- a/code/Model/Recipient/EmailRecipient.php
+++ b/code/Model/Recipient/EmailRecipient.php
@@ -41,6 +41,7 @@ use SilverStripe\UserForms\UserForm;
 use SilverStripe\View\Requirements;
 use Symbiote\GridFieldExtensions\GridFieldAddNewInlineButton;
 use Symbiote\GridFieldExtensions\GridFieldEditableColumns;
+use SilverStripe\Core\Injector\Injector;
 
 /**
  * A Form can have multiply members / emails to email the submission
@@ -151,7 +152,8 @@ class EmailRecipient extends DataObject
 
         $formID = Controller::curr()->getRequest()->getSession()->get($sessionNamespace . '.currentPage');
         if ($formID) {
-            return UserDefinedForm::get()->byID($formID);
+            $parent_class = get_class(Injector::inst()->get(UserDefinedForm::class));
+            return $parent_class::get()->byID($formID);
         }
     }
 


### PR DESCRIPTION
I'm using dnadesign/silverstripe-elemental-userforms module.
So I need to get rid of UserDefinedForm page I have following configuration at app/_config.yml:

```
SilverStripe\Core\Injector\Injector:
  SilverStripe\UserForms\Model\UserDefinedForm:
    class: Site\Extensions\CMSMain_HiddenClass
```

and following replacement class:

```
namespace Site\Extensions;

use SilverStripe\ORM\HiddenClass;
use Page;

class CMSMain_HiddenClass extends Page implements HiddenClass
{
}
```

UserDefinedForm::get()
will return MySQL error that UserDefinedForm table doesn't exists