### PR TITLE
DOCS additional note to keeping uploaded files secure

### DIFF
--- a/docs/en/userguide/field-types.md
+++ b/docs/en/userguide/field-types.md
@@ -52,11 +52,13 @@ The folder that this field uploads to can be customised by selecting "Show Optio
 and then selecting a new folder from the "Select upload folder" option. If no folder
 is selected it will upload by default to the "Uploads" folder.
 
-Only certain file extensions are considered safe for upload,
-e.g. webserver script files will be denied but images will be allowed.
-The webserver environment also imposes a limit on file size by default.
+If the default "Uploads" folder is used, or if you choose a folder that does not have additional CMS access permissions set, you may be exposing files uploaded via your form to the public, as well as anyone with access to the CMS.
 
-You can set any permissions requirements on the upload folder by finding it in the "Files" area, clicking on it to edit and going to the "Permissions" tab.
+You can set any permission requirements on the upload folder by finding it in the "Files" area, clicking on it to edit and going to the "Permissions" tab.
+
+Only certain file extensions are considered safe for upload,
+e.g. webserver script files will be denied but images will be allowed. The webserver environment also imposes a limit on file size by default.
+
 
 ## Heading
 

--- a/docs/en/userguide/index.md
+++ b/docs/en/userguide/index.md
@@ -21,6 +21,7 @@ This is your responsibility, but here are a few tips to get you started:
  * Ensure you have the necessary consents for processing and storing data according to your legislation (e.g. GDPR) 
  * Only accept form submissions via encrypted transfers (HTTPS) - check our [Secure Coding](https://docs.silverstripe.org/en/4/developer_guides/security/secure_coding/) guidelines
  * Control access to form submissions (via CMS page access controls)
+ * Control access to files uploaded with submissions (via [folder access controls](field-types/#file-upload-field))
  * Create a process to limit the types of data you are allowed to collect via this feature (e.g. no payment information or health data)
  * Create a process for limiting submission storage duration (manual deletion)
  * Consider further safeguards such as at-rest encryption (check [encryption related addons](https://addons.silverstripe.org/add-ons?search=encrypt))    

--- a/docs/en/userguide/index.md
+++ b/docs/en/userguide/index.md
@@ -21,7 +21,7 @@ This is your responsibility, but here are a few tips to get you started:
  * Ensure you have the necessary consents for processing and storing data according to your legislation (e.g. GDPR) 
  * Only accept form submissions via encrypted transfers (HTTPS) - check our [Secure Coding](https://docs.silverstripe.org/en/4/developer_guides/security/secure_coding/) guidelines
  * Control access to form submissions (via CMS page access controls)
- * Control access to files uploaded with submissions (via [folder access controls](field-types/#file-upload-field))
+ * Control access to files uploaded with submissions (via [folder access controls](field-types.md#file-upload-field))
  * Create a process to limit the types of data you are allowed to collect via this feature (e.g. no payment information or health data)
  * Create a process for limiting submission storage duration (manual deletion)
  * Consider further safeguards such as at-rest encryption (check [encryption related addons](https://addons.silverstripe.org/add-ons?search=encrypt))    


### PR DESCRIPTION
Touching up the documentation to advise how uploaded files can be kept secure.

Related (but does not address) #927