### PR TITLE
FIX Add missing space before aria-describedby attribute

### DIFF
--- a/templates/SilverStripe/UserForms/FormField/UserFormsGroupField_holder.ss
+++ b/templates/SilverStripe/UserForms/FormField/UserFormsGroupField_holder.ss
@@ -1,4 +1,4 @@
-<$Tag class="CompositeField $extraClass <% if ColumnCount %>multicolumn<% end_if %>"<% if $Tag == 'fieldset' && $RightTitle %>aria-describedby="{$Name}_right_title"<% end_if %>>
+<$Tag class="CompositeField $extraClass<% if $ColumnCount %> multicolumn<% end_if %>"<% if $Tag == 'fieldset' && $RightTitle %> aria-describedby="{$Name}_right_title"<% end_if %>>
 	<% if $Tag == 'fieldset' && $Legend %>
 		<legend>$Legend</legend>
 	<% end_if %>

--- a/templates/SilverStripe/UserForms/Model/EditableFormField.ss
+++ b/templates/SilverStripe/UserForms/Model/EditableFormField.ss
@@ -1,1 +1,1 @@
-<input $AttributesHTML<% if $RightTitle %>aria-describedby="{$Name}_right_title" <% end_if %>/>
+<input $AttributesHTML<% if $RightTitle %> aria-describedby="{$Name}_right_title"<% end_if %>/>

--- a/templates/SilverStripe/UserForms/Model/EditableFormField/EditableCheckbox.ss
+++ b/templates/SilverStripe/UserForms/Model/EditableFormField/EditableCheckbox.ss
@@ -1,2 +1,2 @@
-<input $AttributesHTML<% if $RightTitle %>aria-describedby="{$Name}_right_title" <% end_if %>/>
+<input $AttributesHTML<% if $RightTitle %> aria-describedby="{$Name}_right_title"<% end_if %>/>
 <% if $Title %><label class="left" for="$ID">$Title</label><% end_if %>

--- a/templates/SilverStripe/UserForms/Model/EditableFormField/EditableDropdown.ss
+++ b/templates/SilverStripe/UserForms/Model/EditableFormField/EditableDropdown.ss
@@ -1,4 +1,4 @@
-<select $AttributesHTML <% if $RightTitle %>aria-describedby="{$Name}_right_title"<% end_if %>>
+<select $AttributesHTML<% if $RightTitle %> aria-describedby="{$Name}_right_title"<% end_if %>>
 <% loop $Options %>
 	<option value="$Value.XML"<% if $Selected %> selected="selected"<% end_if %><% if $Disabled %> disabled="disabled"<% end_if %>>$Title.XML</option>
 <% end_loop %>

--- a/templates/SilverStripe/UserForms/Model/EditableFormField/EditableTextareaField.ss
+++ b/templates/SilverStripe/UserForms/Model/EditableFormField/EditableTextareaField.ss
@@ -1,1 +1,1 @@
-<textarea $AttributesHTML<% if $RightTitle %>aria-describedby="{$Name}_right_title" <% end_if %>>$Value</textarea>
+<textarea $AttributesHTML<% if $RightTitle %> aria-describedby="{$Name}_right_title"<% end_if %>>$Value</textarea>


### PR DESCRIPTION
The `aria-describedby` attribute, when present, was being glued onto the field attributes in some cases.

This adds the space in front of the attribute so it's always there.