### PR TITLE
NEW Make Unrestricted Folder warning conditional, improve language

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -31,7 +31,7 @@
     ],
     "require": {
         "php": ">=7.1",
-        "silverstripe/cms": "^4.0",
+        "silverstripe/cms": "^4.6",
         "symbiote/silverstripe-gridfieldextensions": "^3.1",
         "silverstripe/segment-field": "^2.0",
         "silverstripe/versioned": "^1.0"

--- a/lang/en.yml
+++ b/lang/en.yml
@@ -261,7 +261,7 @@ en:
     EMAIL_RECIPIENT_UNSAVED_FORM: 'You will be able to select from valid form fields after saving this record.'
     EmailFromContent: 'The from address allows you to set who the email comes from. On most servers this will need to be set to an email address on the same domain name as your site. For example on yoursite.com the from address may need to be something@yoursite.com. You can however, set any email address you wish as the reply to address.'
     FROMADDRESS: 'Send email from'
-    FileUploadWarning: 'Files uploaded through this field could be publicly accessible if the exact URL is known'
+    UnrestrictedFileUploadWarning: 'Access to the current upload folder "{path}" is not restricted. Uploaded files will be publicly accessible if the exact URL is known.'
     HIDEFORMDATA: 'Hide form data from email?'
     ORSELECTAFIELDTOUSEASFROM: '.. or select a field to use as reply to address'
     ORSELECTAFIELDTOUSEASTO: '.. or select a field to use as the to address'


### PR DESCRIPTION
This warning previously appeared at all times, and had vague language, making it hard for a user to discern whether the folder in use was actually dangerous or not.

Now, the warning only appears when it is relevant, is styled as a warning rather than a notice, and has much clearer language.

**Before:**

<img width="1068" alt="image" src="https://user-images.githubusercontent.com/242621/81363326-23519780-9137-11ea-9d39-b38b7adc796d.png">


**After:**

<img width="1068" alt="image" src="https://user-images.githubusercontent.com/242621/81363269-05843280-9137-11ea-9920-fb680ad43508.png">

This PR also bumps the minimum core requirement to ^4.6, in order to take advantage of the new `File::hasRestrictedAccess()` method.

Resolves #962.
