### PR TITLE
Update for 5.6

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,7 @@ services:
 
 env:
   global:
-    - COMPOSER_ROOT_VERSION=5.x-dev
+    - COMPOSER_ROOT_VERSION=5.6.x-dev
     - TRAVIS_NODE_VERSION="10"
 
 matrix:


### PR DESCRIPTION
composer.json does not need to be updated
```
    "require": {
        "php": ">=7.1",
        "silverstripe/cms": "^4.6",
        "symbiote/silverstripe-gridfieldextensions": "^3.1",
        "silverstripe/segment-field": "^2.0",
        "silverstripe/versioned": "^1.0"
    },
```