### PR TITLE
Fix builds for 5.2, 5.3, 5.4

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,7 @@ dist: xenial
 
 services:
   - mysql
+  - postgresql
 
 env:
   global:


### PR DESCRIPTION
Builds for 5.2, 5.3 are 5.4 broken because they test postgresql without installing it.