### PR TITLE
FIX Use translation string that belongs to UserDefinedFormAdmin

### DIFF
--- a/code/Control/UserDefinedFormAdmin.php
+++ b/code/Control/UserDefinedFormAdmin.php
@@ -4,7 +4,6 @@ namespace SilverStripe\UserForms\Control;
 
 use SilverStripe\Admin\LeftAndMain;
 use SilverStripe\Assets\Folder;
-use SilverStripe\CMS\Controllers\CMSMain;
 use SilverStripe\Control\HTTPRequest;
 use SilverStripe\Control\HTTPResponse;
 use SilverStripe\Control\HTTPResponse_Exception;
@@ -193,7 +192,7 @@ class UserDefinedFormAdmin extends LeftAndMain
             FormAction::create('confirmfolder', _t(__CLASS__.'.FORM_ACTION_CONFIRM', 'Save and continue'))
                 ->setUseButtonTag(false)
                 ->addExtraClass('btn btn-primary'),
-            FormAction::create("cancel", _t(CMSMain::class . '.Cancel', "Cancel"))
+            FormAction::create("cancel", _t(__CLASS__ . '.CANCEL', "Cancel"))
                 ->addExtraClass('btn btn-secondary')
                 ->setUseButtonTag(true)
         );

--- a/lang/en.yml
+++ b/lang/en.yml
@@ -25,6 +25,7 @@ en:
     TEXTONCLEAR: 'Text on clear button:'
     TEXTONSUBMIT: 'Text on submit button:'
   SilverStripe\UserForms\Control\UserDefinedFormAdmin:
+    CANCEL: 'Cancel'
     CONFIRM_FOLDER_LABEL_A: 'Files that your users upload should be stored carefully to reduce the risk of exposing sensitive data. Ensure the folder you select can only be viewed by appropriate parties. Folder permissions can be managed within the Files area.'
     CONFIRM_FOLDER_LABEL_B: 'The folder selected will become the default for this form. This can be changed on an individual basis in the <i>File upload field.</i>'
     FOLDER_OPTIONS_EXISTING: 'Use an existing folder'


### PR DESCRIPTION
This is to for the benefit of cow translate which did not like the use of `_t(CMSMain::class`