### PR TITLE
FIX unrequire fields when they become dataless

### DIFF
--- a/code/Model/EditableFormField.php
+++ b/code/Model/EditableFormField.php
@@ -411,12 +411,13 @@ class EditableFormField extends DataObject
 
     public function onBeforeWrite()
     {
+        parent::onBeforeWrite();
+
         $formField = $this->getFormField();
         if ($formField && !$formField->hasData()) {
             $this->Required = false;
         }
 
-        parent::onBeforeWrite();
 
         // Set a field name.
         if (!$this->Name) {

--- a/code/Model/EditableFormField.php
+++ b/code/Model/EditableFormField.php
@@ -418,7 +418,6 @@ class EditableFormField extends DataObject
             $this->Required = false;
         }
 
-
         // Set a field name.
         if (!$this->Name) {
             // New random name

--- a/code/Model/EditableFormField.php
+++ b/code/Model/EditableFormField.php
@@ -411,6 +411,11 @@ class EditableFormField extends DataObject
 
     public function onBeforeWrite()
     {
+        $formField = $this->getFormField();
+        if ($formField && !$formField->hasData()) {
+            $this->Required = false;
+        }
+
         parent::onBeforeWrite();
 
         // Set a field name.

--- a/tests/Model/EditableFormFieldTest.php
+++ b/tests/Model/EditableFormFieldTest.php
@@ -10,6 +10,7 @@ use SilverStripe\UserForms\Model\EditableFormField;
 use SilverStripe\UserForms\Model\EditableFormField\EditableCheckbox;
 use SilverStripe\UserForms\Model\EditableFormField\EditableDropdown;
 use SilverStripe\UserForms\Model\EditableFormField\EditableFileField;
+use SilverStripe\UserForms\Model\EditableFormField\EditableLiteralField;
 use SilverStripe\UserForms\Model\EditableFormField\EditableOption;
 use SilverStripe\UserForms\Model\EditableFormField\EditableRadioField;
 use SilverStripe\UserForms\Model\EditableFormField\EditableTextField;
@@ -291,5 +292,22 @@ class EditableFormFieldTest extends FunctionalTest
         /** @var EditableFormField $field */
         $field = $this->objFromFixture(EditableTextField::class, $fieldName);
         $this->assertEquals($expected, $field->isDisplayed($data));
+    }
+
+    public function testChangingDataFieldTypeToDatalessRemovesRequiredSetting()
+    {
+        $requiredTextField = $this->objFromFixture(EditableTextField::class, 'required-text');
+        $fieldId = $requiredTextField->ID;
+
+        $this->assertTrue((bool)$requiredTextField->Required);
+        $literalField = $requiredTextField->newClassInstance(EditableLiteralField::class);
+
+        $this->assertTrue((bool)$literalField->Required);
+
+        $literalField->write();
+        $this->assertFalse((bool)$literalField->Required);
+
+        $updatedField = EditableFormField::get()->byId($fieldId);
+        $this->assertFalse((bool)$updatedField->Required);
     }
 }

--- a/tests/Model/EditableFormFieldTest.php
+++ b/tests/Model/EditableFormFieldTest.php
@@ -298,10 +298,9 @@ class EditableFormFieldTest extends FunctionalTest
     {
         $requiredTextField = $this->objFromFixture(EditableTextField::class, 'required-text');
         $fieldId = $requiredTextField->ID;
-
         $this->assertTrue((bool)$requiredTextField->Required);
-        $literalField = $requiredTextField->newClassInstance(EditableLiteralField::class);
 
+        $literalField = $requiredTextField->newClassInstance(EditableLiteralField::class);
         $this->assertTrue((bool)$literalField->Required);
 
         $literalField->write();


### PR DESCRIPTION
When fields that collect input data are changed in configuration via the
CMS to become fields that no longer collect input data (e.g. TextField
-> HTML Block), submitting the resulting form results in a fatal error,
server 500 response, etc. due to trying to check if a field without data
(ever) has data in it.

To circumvent this we can set the required state to false if the field
is being converted to one that does not collect data (which FormField
API conveniently provides a check for).

Fixes #1007 