### PR TITLE
NEW Maximum email attachment size can be configured

### DIFF
--- a/tests/php/Control/fixtures/SizeStringTestableController.php
+++ b/tests/php/Control/fixtures/SizeStringTestableController.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace SilverStripe\UserForms\Tests\Control\fixtures;
+
+use SilverStripe\Dev\TestOnly;
+use SilverStripe\UserForms\Control\UserDefinedFormController;
+
+class SizeStringTestableController extends UserDefinedFormController implements TestOnly
+{
+    public function convertSizeStringToBytes($sizeString)
+    {
+        return $this->parseByteSizeString($sizeString);
+    }
+}


### PR DESCRIPTION
Previously hard coded size of 1MB meant any file larger was excluded
from recipient emails - often confusing for CMS admins configuring an
advanced use case for a userform, expecting to recieve files to begin a
business process external to the website.

resolves #1008 