### PR TITLE
FIX account for owner class while removing orphans

### DIFF
--- a/code/Extension/UserFormFieldEditorExtension.php
+++ b/code/Extension/UserFormFieldEditorExtension.php
@@ -196,6 +196,7 @@ class UserFormFieldEditorExtension extends DataExtension
         $live = Versioned::get_by_stage(EditableFormField::class, Versioned::LIVE)
             ->filter([
                 'ParentID' => $this->owner->ID,
+                'ParentClass' => get_class($this->owner),
             ]);
 
         if (!empty($seenIDs)) {

--- a/tests/Extension/UserFormBlockStub.php
+++ b/tests/Extension/UserFormBlockStub.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace SilverStripe\UserForms\Tests\Extension;
+
+use SilverStripe\Dev\TestOnly;
+use SilverStripe\ORM\DataObject;
+use SilverStripe\UserForms\UserForm;
+
+/**
+ * A stand in for e.g. dnadesigned/silverstripe-elemental-userforms
+ */
+class UserFormBlockStub extends DataObject implements TestOnly
+{
+    use UserForm;
+}

--- a/tests/Extension/UserFormFieldEditorExtensionTest.php
+++ b/tests/Extension/UserFormFieldEditorExtensionTest.php
@@ -30,7 +30,7 @@ class UserFormFieldEditorExtensionTest extends SapphireTest
         $block = $this->objFromFixture(UserFormBlockStub::class, 'block');
 
         // assert setup
-        
+        $this->assertSame($page->ID, $block->ID);
         $this->assertCount(1, $page->Fields());
         $this->assertCount(3, $block->Fields());
 
@@ -40,6 +40,8 @@ class UserFormFieldEditorExtensionTest extends SapphireTest
 
         $initialLivePage = UserDefinedForm::get()->First();
         $initialLiveBlock = UserFormBlockStub::get()->First();
+
+        $this->assertSame($initialLivePage->ID, $initialLiveBlock->ID);
         $this->assertCount(1, $initialLivePage->Fields());
         $this->assertCount(3, $initialLiveBlock->Fields());
 

--- a/tests/Extension/UserFormFieldEditorExtensionTest.php
+++ b/tests/Extension/UserFormFieldEditorExtensionTest.php
@@ -30,7 +30,7 @@ class UserFormFieldEditorExtensionTest extends SapphireTest
         $block = $this->objFromFixture(UserFormBlockStub::class, 'block');
 
         // assert setup
-        $this->assertSame($page->ID, $block->ID);
+        
         $this->assertCount(1, $page->Fields());
         $this->assertCount(3, $block->Fields());
 
@@ -40,7 +40,6 @@ class UserFormFieldEditorExtensionTest extends SapphireTest
 
         $initialLivePage = UserDefinedForm::get()->First();
         $initialLiveBlock = UserFormBlockStub::get()->First();
-        $this->assertSame($initialLivePage->ID, $initialLiveBlock->ID);
         $this->assertCount(1, $initialLivePage->Fields());
         $this->assertCount(3, $initialLiveBlock->Fields());
 

--- a/tests/Extension/UserFormFieldEditorExtensionTest.php
+++ b/tests/Extension/UserFormFieldEditorExtensionTest.php
@@ -1,0 +1,76 @@
+<?php
+
+namespace SilverStripe\UserForms\Tests\Extension;
+
+use SilverStripe\Dev\SapphireTest;
+use SilverStripe\UserForms\Model\EditableFormField\EditableEmailField;
+use SilverStripe\UserForms\Model\UserDefinedForm;
+use SilverStripe\Versioned\Versioned;
+
+class UserFormFieldEditorExtensionTest extends SapphireTest
+{
+    protected static $fixture_file = 'UserFormFieldEditorExtensionTest.yml';
+
+    protected static $extra_dataobjects = [
+        UserFormBlockStub::class,
+    ];
+
+    protected function setUp()
+    {
+        parent::setUp();
+        $page = $this->objFromFixture(UserDefinedForm::class, 'page');
+        $block = $this->objFromFixture(UserFormBlockStub::class, 'block');
+        $page->publishRecursive();
+        $block->publishRecursive();
+    }
+
+    public function testOrphanRemovalDoesNotAffectOtherClassesWithTheSameID()
+    {
+        $page = $this->objFromFixture(UserDefinedForm::class, 'page');
+        $block = $this->objFromFixture(UserFormBlockStub::class, 'block');
+
+        // assert setup
+        $this->assertSame($page->ID, $block->ID);
+        $this->assertCount(1, $page->Fields());
+        $this->assertCount(3, $block->Fields());
+
+        // ensure setup has affected live mode too
+        $origReadingMode = Versioned::get_reading_mode();
+        Versioned::set_reading_mode(Versioned::LIVE);
+
+        $initialLivePage = UserDefinedForm::get()->First();
+        $initialLiveBlock = UserFormBlockStub::get()->First();
+        $this->assertSame($initialLivePage->ID, $initialLiveBlock->ID);
+        $this->assertCount(1, $initialLivePage->Fields());
+        $this->assertCount(3, $initialLiveBlock->Fields());
+
+        Versioned::set_reading_mode($origReadingMode);
+
+        // execute change
+        $newField = new EditableEmailField();
+        $newField->update([
+            'Name' => 'basic_email_name',
+            'Title' => 'Page Email Field'
+        ]);
+        $page->Fields()->add($newField);
+        $page->publishRecursive();
+
+        // assert effect of change
+        $checkPage = UserDefinedForm::get()->First();
+        $checkBlock = UserFormBlockStub::get()->First();
+
+        $this->assertCount(2, $checkPage->Fields());
+        $this->assertCount(3, $checkBlock->Fields());
+
+        // ensure this is true for live mode too
+        $origReadingMode = Versioned::get_reading_mode();
+        Versioned::set_reading_mode(Versioned::LIVE);
+
+        $checkLivePage = UserDefinedForm::get()->First();
+        $checkLiveBlock = UserFormBlockStub::get()->First();
+        $this->assertCount(2, $checkLivePage->Fields());
+        $this->assertCount(3, $checkLiveBlock->Fields());
+
+        Versioned::set_reading_mode($origReadingMode);
+    }
+}

--- a/tests/Extension/UserFormFieldEditorExtensionTest.yml
+++ b/tests/Extension/UserFormFieldEditorExtensionTest.yml
@@ -1,0 +1,21 @@
+SilverStripe\UserForms\Model\UserDefinedForm:
+  page:
+SilverStripe\UserForms\Tests\Extension\UserFormBlockStub:
+  block:
+SilverStripe\UserForms\Model\EditableFormField\EditableTextField:
+  page-text-field:
+    Name: basic_text_name
+    Title: Page Text Field
+    Parent: =>SilverStripe\UserForms\Model\UserDefinedForm.page
+  block-text-field-1:
+    Name: basic_text_name_2
+    Title: Block Text Field
+    Parent: =>SilverStripe\UserForms\Tests\Extension\UserFormBlockStub.block
+  block-text-field-2:
+    Name: basic_text_name_3
+    Title: Block Text Field
+    Parent: =>SilverStripe\UserForms\Tests\Extension\UserFormBlockStub.block
+  block-text-field-3:
+    Name: basic_text_name_4
+    Title: Block Text Field
+    Parent: =>SilverStripe\UserForms\Tests\Extension\UserFormBlockStub.block

--- a/tests/Extension/UserFormFieldEditorExtensionTest.yml
+++ b/tests/Extension/UserFormFieldEditorExtensionTest.yml
@@ -1,7 +1,9 @@
 SilverStripe\UserForms\Model\UserDefinedForm:
   page:
+    ID: 9999
 SilverStripe\UserForms\Tests\Extension\UserFormBlockStub:
   block:
+    ID: 9999
 SilverStripe\UserForms\Model\EditableFormField\EditableTextField:
   page-text-field:
     Name: basic_text_name


### PR DESCRIPTION
Previously the owner class is not taken into account, so two separate
data objects with the same ID and a different set of Field children
could end up wiping each other's fields out of the published site.

Closes #1014