### PR TITLE
FIX correctly calculate MaxFileSizeMB

### DIFF
--- a/code/Model/EditableFormField/EditableFileField.php
+++ b/code/Model/EditableFormField/EditableFileField.php
@@ -185,7 +185,7 @@ class EditableFileField extends EditableFormField
         $result = parent::validate();
 
         $max = static::get_php_max_file_size();
-        if ($this->MaxFileSizeMB * 1024 > $max) {
+        if ($this->MaxFileSizeMB * 1024 * 1024 > $max) {
             $result->addError("Your max file size limit can't be larger than the server's limit of {$this->getPHPMaxFileSizeMB()}.");
         }
 


### PR DESCRIPTION
The inputted value is intended to represent megabytes, but is only
multiplied by 1024 - meaning it'd represent kilobytes. This is then used
to compare with the PHP setting number, which is bytes in the range of
megabytes. Kilobytes are always under megabytes, meaning size
comparisons elsewhere in the code are always true.
We should ensure the calculation for validation is correct.

Closes #977 