### PR TITLE
Fix <br> in textarea on validation redirect

### DIFF
--- a/templates/SilverStripe/UserForms/Model/EditableFormField/EditableTextareaField.ss
+++ b/templates/SilverStripe/UserForms/Model/EditableFormField/EditableTextareaField.ss
@@ -1,1 +1,1 @@
-<textarea $AttributesHTML<% if $RightTitle %> aria-describedby="{$Name}_right_title"<% end_if %>>$Value.RAW</textarea>
+<textarea $AttributesHTML<% if $RightTitle %> aria-describedby="{$Name}_right_title"<% end_if %>>$Value.HTMLATT</textarea>

--- a/templates/SilverStripe/UserForms/Model/EditableFormField/EditableTextareaField.ss
+++ b/templates/SilverStripe/UserForms/Model/EditableFormField/EditableTextareaField.ss
@@ -1,1 +1,1 @@
-<textarea $AttributesHTML<% if $RightTitle %> aria-describedby="{$Name}_right_title"<% end_if %>>$Value</textarea>
+<textarea $AttributesHTML<% if $RightTitle %> aria-describedby="{$Name}_right_title"<% end_if %>>$Value.RAW</textarea>


### PR DESCRIPTION
When someone inserts break lines in a text area field and submits the form, if the form validation fails and the form is redirected back the text area field will populate with <br> displayed in the field.

This fixes that issue.

Example input:
![before submission](https://user-images.githubusercontent.com/2616373/103498938-50a53f80-4e96-11eb-84d1-29a1a80be245.png)

After submission redirect back:
![after submission with br tags visible](https://user-images.githubusercontent.com/2616373/103498985-77fc0c80-4e96-11eb-8f36-e008668cfa43.png)
