### PR TITLE
FIX Include merge fields in plain text emails

### DIFF
--- a/code/Control/UserDefinedFormController.php
+++ b/code/Control/UserDefinedFormController.php
@@ -345,6 +345,8 @@ JS
                 // Add specific template data for the current recipient
                 $emailData['HideFormData'] =  (bool) $recipient->HideFormData;
                 // Include any parsed merge field references from the CMS editor - this is already escaped
+                // This string substitution works for both HTML and plain text emails.
+                // $recipient->getEmailBodyContent() will retrieve the relevant version of the email
                 $emailData['Body'] = SSViewer::execute_string($recipient->getEmailBodyContent(), $mergeFields);
 
                 // Push the template data to the Email's data
@@ -414,7 +416,8 @@ JS
                 $this->extend('updateEmail', $email, $recipient, $emailData);
 
                 if ((bool)$recipient->SendPlain) {
-                    $body = strip_tags($recipient->getEmailBodyContent()) . "\n";
+                    // decode previously encoded html tags because the email is being sent as text/plain
+                    $body = html_entity_decode($emailData['Body']) . "\n";
                     if (isset($emailData['Fields']) && !$emailData['HideFormData']) {
                         foreach ($emailData['Fields'] as $field) {
                             if ($field instanceof SubmittedFileField) {

--- a/tests/php/UserFormsTest.yml
+++ b/tests/php/UserFormsTest.yml
@@ -317,12 +317,14 @@ SilverStripe\UserForms\Model\Recipient\EmailRecipient:
     EmailAddress: test@example.com
     EmailSubject: Email Subject
     EmailFrom: no-reply@example.com
+    EmailBodyHtml: '<div class="form__field-holder"><span id="Form_ItemEditForm_MergeField" class="readonly">My body html $basic_text_name</span></div>'
 
   no-html:
     EmailAddress: nohtml@example.com
     EmailSubject: Email Subject
     EmailFrom: no-reply@example.com
     SendPlain: true
+    EmailBody: 'My body text $basic_text_name'
 
   no-data:
     EmailAddress: nodata@example.com


### PR DESCRIPTION
Fixes https://github.com/silverstripe/silverstripe-userforms/issues/1026

For testing, to add a merge-field to the recipient email content e.g. `$EditableTextField_1d3c6`

You can find the exact value to use by editing the relevant form field in the user defined form and copying the value from the field labelled 'Merge field'

If you don't have emailing functionality setup on your local, you can set a debug breakpoint around UserDefinedFormController:418 to see the email body content at this point