### PR TITLE
FIX Show correct fields in email preview

### DIFF
--- a/code/Model/Recipient/UserFormRecipientItemRequest.php
+++ b/code/Model/Recipient/UserFormRecipientItemRequest.php
@@ -53,16 +53,12 @@ class UserFormRecipientItemRequest extends GridFieldDetailForm_ItemRequest
     protected function getPreviewFieldData()
     {
         $data = ArrayList::create();
-
-        $fields = $this->record->Form()->Fields()->filter(
-            'ClassName:not',
-            [
-                EditableLiteralField::class,
-                EditableFormHeading::class,
-            ]
-        );
+        $fields = $this->record->Form()->Fields();
 
         foreach ($fields as $field) {
+            if (!$field->showInReports()) {
+                continue;
+            }
             $data->push(ArrayData::create([
                 'Name' => $field->dbObject('Name'),
                 'Title' => $field->dbObject('Title'),

--- a/tests/Model/Recipient/UserFormRecipientItemRequestTest.php
+++ b/tests/Model/Recipient/UserFormRecipientItemRequestTest.php
@@ -1,0 +1,47 @@
+<?php
+
+namespace SilverStripe\UserForms\Tests\Model\Recipient;
+
+use SilverStripe\Dev\SapphireTest;
+use SilverStripe\ORM\PolymorphicHasManyList;
+use SilverStripe\UserForms\Model\Recipient\EmailRecipient;
+use SilverStripe\UserForms\Model\Recipient\UserFormRecipientItemRequest;
+use SilverStripe\UserForms\Model\UserDefinedForm;
+
+class UserFormRecipientItemRequestTest extends SapphireTest
+{
+    public function testShowInReportsAffectsPreview()
+    {
+        // classes where showInReports() returns false
+        $namespace = 'SilverStripe\UserForms\Model\EditableFormField';
+        $falseClasses = ['EditableFieldGroup', 'EditableFieldGroupEnd', 'EditableFormStep'];
+        // some classes where showInReports() returns true (inherits from EditableFormField)
+        $trueClasses = ['EditableTextField', 'EditableEmailField', 'EditableDateField'];
+        $form = new UserDefinedForm();
+        $form->write();
+        /** @var PolymorphicHasManyList $fields */
+        $fields = $form->Fields();
+        foreach (array_merge($falseClasses, $trueClasses) as $class) {
+            $fqcn = "$namespace\\$class";
+            $obj = new $fqcn();
+            $obj->Name = 'My' . $class;
+            $obj->write();
+            $fields->add($obj);
+        }
+        $recipient = new EmailRecipient();
+        $recipient->EmailAddress = 'to@example.com';
+        $recipient->EmailFrom = 'from@example.com';
+        $recipient->EmailTemplate = 'email/SubmittedFormEmail';
+        $recipient->Form = $form;
+        $recipient->write();
+        $recipient->setComponent('Form', $form);
+        $request = new UserFormRecipientItemRequest(null, null, $recipient, null, '');
+        $html = $request->preview()->getValue();
+        foreach ($falseClasses as $class) {
+            $this->assertNotContains('My' . $class, $html);
+        }
+        foreach ($trueClasses as $class) {
+            $this->assertContains('My' . $class, $html);
+        }
+    }
+}


### PR DESCRIPTION
[Original PR](https://github.com/silverstripe/silverstripe-userforms/pull/1024) - thanks @mikeyc7m - I've put you down as a co-author in the commit message

Fixes https://github.com/silverstripe/silverstripe-userforms/issues/917

Note: `EditableLiteralField` and `EditableFormHeading` have a dynamic `showInReports()` function

```
    public function showInReports()
    {
        return !$this->HideFromReports;
    }
```

Which is why I removed the database filtering query, because sometime this should actually be in the preview

The code that create the actual email (as opposed to the preview which this code deals with) also uses showInReports()

https://github.com/silverstripe/silverstripe-userforms/blob/5/code/Control/UserDefinedFormController.php#L240
