### PR TITLE
Use correct directory separator on Windows when selecting email templates

### DIFF
--- a/code/Model/Recipient/EmailRecipient.php
+++ b/code/Model/Recipient/EmailRecipient.php
@@ -521,8 +521,8 @@ class EmailRecipient extends DataObject
             }
             $templatePath = substr($absoluteFilename, strlen($prefixToStrip) + 1);
 
-            // Optionally remove "templates/" prefixes
-            if (preg_match('/(?<=templates\/).*$/', $templatePath, $matches)) {
+            // Optionally remove "templates/" ("templates\" on Windows respectively) prefixes
+            if (preg_match('#(?<=templates' . DIRECTORY_SEPARATOR . ').*$#', $templatePath, $matches)) {
                 $templatePath = $matches[0];
             }
 


### PR DESCRIPTION
I've also changed the regex delimiter to `#` to avoid having to use preg_quote but can change to that if preferred.

Fix for #1039.