### PR TITLE
FIX Uploaded files not appearing in emails and cleanup deleted files.

### DIFF
--- a/code/Model/Submission/SubmittedFileField.php
+++ b/code/Model/Submission/SubmittedFileField.php
@@ -4,6 +4,7 @@ namespace SilverStripe\UserForms\Model\Submission;
 
 use SilverStripe\Assets\File;
 use SilverStripe\ORM\FieldType\DBField;
+use SilverStripe\Versioned\Versioned;
 
 /**
  * A file uploaded on a {@link UserDefinedForm} and attached to a single
@@ -21,6 +22,14 @@ class SubmittedFileField extends SubmittedFormField
 
     private static $table_name = 'SubmittedFileField';
 
+    private static $owns = [
+        'UploadedFile'
+    ];
+
+    private static $cascade_deletes = [
+        'UploadedFile'
+    ];
+
     /**
      * Return the value of this field for inclusion into things such as
      * reports.
@@ -31,7 +40,7 @@ class SubmittedFileField extends SubmittedFormField
     {
         $name = $this->getFileName();
         $link = $this->getLink();
-        $title = _t(__CLASS__.'.DOWNLOADFILE', 'Download File');
+        $title = _t(__CLASS__ . '.DOWNLOADFILE', 'Download File');
 
         if ($link) {
             return DBField::create_field('HTMLText', sprintf(
@@ -72,14 +81,14 @@ class SubmittedFileField extends SubmittedFormField
     /**
      * As uploaded files are stored in draft by default, this retrieves the
      * uploaded file from draft mode rather than using the current stage.
-     * 
+     *
      * @return File
      */
-    public function getUploadedFileFromDraft(): ?File
+    public function getUploadedFileFromDraft()
     {
         $fileId = $this->UploadedFileID;
 
-        return Versioned::withVersionedMode(function() use ($fileId) {
+        return Versioned::withVersionedMode(function () use ($fileId) {
             Versioned::set_stage(Versioned::DRAFT);
 
             return File::get()->byID($fileId);

--- a/code/Model/Submission/SubmittedFileField.php
+++ b/code/Model/Submission/SubmittedFileField.php
@@ -62,12 +62,28 @@ class SubmittedFileField extends SubmittedFormField
      */
     public function getLink()
     {
-        $file = $this->UploadedFile();
-        if ($file && $file->exists()) {
-            if (trim($file->getFilename(), '/') != trim(ASSETS_DIR, '/')) {
-                return $this->UploadedFile()->AbsoluteLink();
+        if ($file = $this->getUploadedFileFromDraft()) {
+            if ($file->exists()) {
+                return $file->getAbsoluteURL();
             }
         }
+    }
+
+    /**
+     * As uploaded files are stored in draft by default, this retrieves the
+     * uploaded file from draft mode rather than using the current stage.
+     * 
+     * @return File
+     */
+    public function getUploadedFileFromDraft(): ?File
+    {
+        $fileId = $this->UploadedFileID;
+
+        return Versioned::withVersionedMode(function() use ($fileId) {
+            Versioned::set_stage(Versioned::DRAFT);
+
+            return File::get()->byID($fileId);
+        });
     }
 
     /**
@@ -77,8 +93,8 @@ class SubmittedFileField extends SubmittedFormField
      */
     public function getFileName()
     {
-        if ($this->UploadedFile()) {
-            return $this->UploadedFile()->Name;
+        if ($file = $this->getUploadedFileFromDraft()) {
+            return $file->Name;
         }
     }
 }

--- a/tests/php/Model/SubmittedFileFieldTest.php
+++ b/tests/php/Model/SubmittedFileFieldTest.php
@@ -1,0 +1,64 @@
+<?php
+
+namespace SilverStripe\UserForms\Tests\Model;
+
+use SilverStripe\Assets\Dev\TestAssetStore;
+use SilverStripe\Assets\File;
+use SilverStripe\Dev\SapphireTest;
+use SilverStripe\UserForms\Model\Submission\SubmittedFileField;
+use SilverStripe\UserForms\Model\Submission\SubmittedForm;
+use SilverStripe\Versioned\Versioned;
+
+class SubmittedFileFieldTest extends SapphireTest
+{
+    public function setUp()
+    {
+        parent::setUp();
+
+        TestAssetStore::activate('SubmittedFileFieldTest');
+    }
+
+    public function tearDown()
+    {
+        TestAssetStore::reset();
+
+        parent::tearDown();
+    }
+
+    public function testDeletingSubmissionRemovesFile()
+    {
+        $file = File::create();
+        $file->setFromString('ABC', 'test-SubmittedFileFieldTest.txt');
+        $file->write();
+
+        $submittedForm = SubmittedForm::create();
+        $submittedForm->write();
+
+        $submittedFile = SubmittedFileField::create();
+        $submittedFile->UploadedFileID = $file->ID;
+        $submittedFile->Name = 'File';
+        $submittedFile->ParentID = $submittedForm->ID;
+        $submittedFile->write();
+
+        $this->assertContains('test-SubmittedFileFieldTest', $submittedFile->getFileName(), 'Submitted file is linked');
+
+        $submittedForm->delete();
+        $fileId = $file->ID;
+
+        $draftVersion = Versioned::withVersionedMode(function () use ($fileId) {
+            Versioned::set_stage(Versioned::DRAFT);
+
+            return File::get()->byID($fileId);
+        });
+
+        $this->assertNull($draftVersion, 'Draft file has been deleted');
+
+        $liveVersion = Versioned::withVersionedMode(function () use ($fileId) {
+            Versioned::set_stage(Versioned::LIVE);
+
+            return File::get()->byID($fileId);
+        });
+
+        $this->assertNull($liveVersion, 'Live file has been deleted');
+    }
+}


### PR DESCRIPTION
As files uploaded into `DRAFT` mode ensure that these are still displayed in the submitted form.