### PR TITLE
Stops reply-to address being set to empty, if reply-to field value is empty

### DIFF
--- a/code/Control/UserDefinedFormController.php
+++ b/code/Control/UserDefinedFormController.php
@@ -357,7 +357,7 @@ JS
                 if ($emailFrom && $emailFrom->exists()) {
                     $submittedFormField = $submittedFields->find('Name', $recipient->SendEmailFromField()->Name);
 
-                    if ($submittedFormField && is_string($submittedFormField->Value)) {
+                    if ($submittedFormField && $submittedFormField->Value && is_string($submittedFormField->Value)) {
                         $email->setReplyTo(explode(',', $submittedFormField->Value));
                     }
                 } elseif ($recipient->EmailReplyTo) {


### PR DESCRIPTION
If the Reply-To address for an `Email` is set to an empty string, it results in the email failing to be sent:
> [Emergency] Uncaught Swift_RfcComplianceException: Address in mailbox given [] does not comply with RFC 2822, 3.6.2.

It is possible to create this scenario with UserForms, resulting in a CMS user's actions breaking email submissions for a form. (While setting any Email field as the Reply-To address appears to make that field "required", it is possible to bypass this by making the field conditional.)

This PR simply adds an extra check that the value of the Reply-To field is not empty, before setting the Reply-To address on the `Email`.