### PR TITLE
MNT Fix testOrphanRemovalDoesNotAffectOtherClassesWithTheSameID to start with a First Page Step

### DIFF
--- a/tests/Extension/UserFormFieldEditorExtensionTest.yml
+++ b/tests/Extension/UserFormFieldEditorExtensionTest.yml
@@ -4,6 +4,12 @@ SilverStripe\UserForms\Model\UserDefinedForm:
 SilverStripe\UserForms\Tests\Extension\UserFormBlockStub:
   block:
     ID: 9999
+
+SilverStripe\UserForms\Model\EditableFormField\EditableFormStep:
+  pageFirstStep:
+    Title: First Step
+    Parent: =>SilverStripe\UserForms\Model\UserDefinedForm.page
+
 SilverStripe\UserForms\Model\EditableFormField\EditableTextField:
   page-text-field:
     Name: basic_text_name


### PR DESCRIPTION
This test is broken on the sink because the logic for auto adding the "First Page" is triggered on the sink.

I've updated the test, to manually created the "First Page" step. My guess is that there's something on the sink that forces an early write that doesn't occur on a plain install.

Fixes https://github.com/silverstripeltd/product-issues/issues/424