### PR TITLE
ENH Avoid use of 'new' keyword on injectable classes from this module.

### DIFF
--- a/code/Form/UserForm.php
+++ b/code/Form/UserForm.php
@@ -118,7 +118,7 @@ class UserForm extends Form
      */
     public function getFormFields()
     {
-        $fields = new UserFormsFieldList();
+        $fields = UserFormsFieldList::create();
         $target = $fields;
 
         foreach ($this->controller->data()->Fields() as $field) {
@@ -174,7 +174,7 @@ class UserForm extends Form
             ->filter('Required', true)
             ->column('Name');
         $requiredNames = array_merge($requiredNames, $this->getEmailRecipientRequiredFields());
-        $required = new UserFormsRequiredFields($requiredNames);
+        $required = UserFormsRequiredFields::create($requiredNames);
         $this->extend('updateRequiredFields', $required);
         $required->setForm($this);
         return $required;


### PR DESCRIPTION
It's not uncommon to want to override or enhance some functionality in vendor code that doesn't have extension points, so we should avoid the `new` keyword when instantiating injectable classes from the module.