### PR TITLE
FIX Log any email exceptions gracefully

### DIFF
--- a/code/Control/UserDefinedFormController.php
+++ b/code/Control/UserDefinedFormController.php
@@ -2,6 +2,7 @@
 
 namespace SilverStripe\UserForms\Control;
 
+use Exception;
 use PageController;
 use Psr\Log\LoggerInterface;
 use SilverStripe\AssetAdmin\Controller\AssetAdmin;
@@ -429,9 +430,18 @@ JS
                     }
 
                     $email->setBody($body);
-                    $email->sendPlain();
+
+                    try {
+                        $email->sendPlain();
+                    } catch (Exception $e) {
+                        Injector::inst()->get(LoggerInterface::class)->error($e);
+                    }
                 } else {
-                    $email->send();
+                    try {
+                        $email->send();
+                    } catch (Exception $e) {
+                        Injector::inst()->get(LoggerInterface::class)->error($e);
+                    }
                 }
             }
         }


### PR DESCRIPTION
If an email send() generates any errors such as invalid template or API exceptions then capture the error in the logs rather than displaying the error to the user.