### PR TITLE
FIX Ensure all fields are available for updateCMSFields().

### DIFF
--- a/code/Model/EditableFormField/EditableCheckbox.php
+++ b/code/Model/EditableFormField/EditableCheckbox.php
@@ -33,14 +33,14 @@ class EditableCheckbox extends EditableFormField
      */
     public function getCMSFields()
     {
-        $fields = parent::getCMSFields();
+        $this->beforeUpdateCMSFields(function (FieldList $fields) {
+            $fields->replaceField('Default', CheckboxField::create(
+                "CheckedDefault",
+                _t('SilverStripe\\UserForms\\Model\\EditableFormField.CHECKEDBYDEFAULT', 'Checked by Default?')
+            ));
+        });
 
-        $fields->replaceField('Default', CheckboxField::create(
-            "CheckedDefault",
-            _t('SilverStripe\\UserForms\\Model\\EditableFormField.CHECKEDBYDEFAULT', 'Checked by Default?')
-        ));
-
-        return $fields;
+        return parent::getCMSFields();
     }
 
     public function getFormField()

--- a/code/Model/EditableFormField/EditableCountryDropdownField.php
+++ b/code/Model/EditableFormField/EditableCountryDropdownField.php
@@ -5,6 +5,7 @@ namespace SilverStripe\UserForms\Model\EditableFormField;
 use SilverStripe\Core\Manifest\ModuleLoader;
 use SilverStripe\Forms\CheckboxField;
 use SilverStripe\Forms\DropdownField;
+use SilverStripe\Forms\FieldList;
 use SilverStripe\Forms\TextField;
 use SilverStripe\i18n\i18n;
 use SilverStripe\UserForms\Model\EditableCustomRule;
@@ -35,28 +36,28 @@ class EditableCountryDropdownField extends EditableFormField
      */
     public function getCMSFields()
     {
-        $fields = parent::getCMSFields();
+        $this->beforeUpdateCMSFields(function (FieldList $fields) {
+            $fields->removeByName('Default');
+            $fields->addFieldToTab(
+                'Root.Main',
+                DropdownField::create('Default', _t(__CLASS__ . '.DEFAULT', 'Default value'))
+                             ->setSource(i18n::getData()->getCountries())
+                             ->setHasEmptyDefault(true)
+                             ->setEmptyString('---')
+            );
 
-        $fields->removeByName('Default');
-        $fields->addFieldToTab(
-            'Root.Main',
-            DropdownField::create('Default', _t(__CLASS__ . '.DEFAULT', 'Default value'))
-                         ->setSource(i18n::getData()->getCountries())
-                         ->setHasEmptyDefault(true)
-                         ->setEmptyString('---')
-        );
+            $fields->addFieldToTab(
+                'Root.Main',
+                CheckboxField::create('UseEmptyString', _t(__CLASS__ . '.USE_EMPTY_STRING', 'Set default empty string'))
+            );
 
-        $fields->addFieldToTab(
-            'Root.Main',
-            CheckboxField::create('UseEmptyString', _t(__CLASS__ . '.USE_EMPTY_STRING', 'Set default empty string'))
-        );
+            $fields->addFieldToTab(
+                'Root.Main',
+                TextField::create('EmptyString', _t(__CLASS__ . '.EMPTY_STRING', 'Empty String'))
+            );
+        });
 
-        $fields->addFieldToTab(
-            'Root.Main',
-            TextField::create('EmptyString', _t(__CLASS__ . '.EMPTY_STRING', 'Empty String'))
-        );
-
-        return $fields;
+        return parent::getCMSFields();
     }
 
     public function getFormField()

--- a/code/Model/EditableFormField/EditableDropdown.php
+++ b/code/Model/EditableFormField/EditableDropdown.php
@@ -36,23 +36,23 @@ class EditableDropdown extends EditableMultipleOptionField
      */
     public function getCMSFields()
     {
-        $fields = parent::getCMSFields();
+        $this->beforeUpdateCMSFields(function (FieldList $fields) {
+            $fields->addFieldToTab(
+                'Root.Main',
+                CheckboxField::create('UseEmptyString')
+                    ->setTitle('Set default empty string')
+            );
 
-        $fields->addFieldToTab(
-            'Root.Main',
-            CheckboxField::create('UseEmptyString')
-                ->setTitle('Set default empty string')
-        );
+            $fields->addFieldToTab(
+                'Root.Main',
+                TextField::create('EmptyString')
+                    ->setTitle('Empty String')
+            );
 
-        $fields->addFieldToTab(
-            'Root.Main',
-            TextField::create('EmptyString')
-                ->setTitle('Empty String')
-        );
+            $fields->removeByName('Default');
+        });
 
-        $fields->removeByName('Default');
-
-        return $fields;
+        return parent::getCMSFields();
     }
 
     /**

--- a/code/Model/EditableFormField/EditableFieldGroup.php
+++ b/code/Model/EditableFormField/EditableFieldGroup.php
@@ -3,6 +3,7 @@
 namespace SilverStripe\UserForms\Model\EditableFormField;
 
 use SilverStripe\Core\Convert;
+use SilverStripe\Forms\FieldList;
 use SilverStripe\Forms\LabelField;
 use SilverStripe\UserForms\FormField\UserFormsGroupField;
 use SilverStripe\UserForms\Model\EditableFormField;
@@ -46,9 +47,11 @@ class EditableFieldGroup extends EditableFormField
 
     public function getCMSFields()
     {
-        $fields = parent::getCMSFields();
-        $fields->removeByName(['MergeField', 'Default', 'Validation', 'DisplayRules']);
-        return $fields;
+        $this->beforeUpdateCMSFields(function (FieldList $fields) {
+            $fields->removeByName(['MergeField', 'Default', 'Validation', 'DisplayRules']);
+        });
+
+        return parent::getCMSFields();
     }
 
     public function getCMSTitle()

--- a/code/Model/EditableFormField/EditableFieldGroupEnd.php
+++ b/code/Model/EditableFormField/EditableFieldGroupEnd.php
@@ -2,6 +2,7 @@
 
 namespace SilverStripe\UserForms\Model\EditableFormField;
 
+use SilverStripe\Forms\FieldList;
 use SilverStripe\Forms\HiddenField;
 use SilverStripe\Forms\LabelField;
 use SilverStripe\Security\Group;
@@ -50,9 +51,11 @@ class EditableFieldGroupEnd extends EditableFormField
 
     public function getCMSFields()
     {
-        $fields = parent::getCMSFields();
-        $fields->removeByName(['MergeField', 'Default', 'Validation', 'DisplayRules']);
-        return $fields;
+        $this->beforeUpdateCMSFields(function (FieldList $fields) {
+            $fields->removeByName(['MergeField', 'Default', 'Validation', 'DisplayRules']);
+        });
+
+        return parent::getCMSFields();
     }
 
     public function getInlineClassnameField($column, $fieldClasses)

--- a/code/Model/EditableFormField/EditableFormHeading.php
+++ b/code/Model/EditableFormField/EditableFormHeading.php
@@ -40,32 +40,32 @@ class EditableFormHeading extends EditableFormField
      */
     public function getCMSFields()
     {
-        $fields = parent::getCMSFields();
+        $this->beforeUpdateCMSFields(function (FieldList $fields) {
+            $fields->removeByName(['Default', 'Validation', 'RightTitle']);
 
-        $fields->removeByName(['Default', 'Validation', 'RightTitle']);
+            $levels = [
+                '1' => '1',
+                '2' => '2',
+                '3' => '3',
+                '4' => '4',
+                '5' => '5',
+                '6' => '6'
+            ];
 
-        $levels = [
-            '1' => '1',
-            '2' => '2',
-            '3' => '3',
-            '4' => '4',
-            '5' => '5',
-            '6' => '6'
-        ];
+            $fields->addFieldsToTab('Root.Main', [
+                DropdownField::create(
+                    'Level',
+                    _t(__CLASS__.'.LEVEL', 'Select Heading Level'),
+                    $levels
+                ),
+                CheckboxField::create(
+                    'HideFromReports',
+                    _t('SilverStripe\\UserForms\\Model\\EditableFormField\\EditableLiteralField.HIDEFROMREPORT', 'Hide from reports?')
+                )
+            ]);
+        });
 
-        $fields->addFieldsToTab('Root.Main', [
-            DropdownField::create(
-                'Level',
-                _t(__CLASS__.'.LEVEL', 'Select Heading Level'),
-                $levels
-            ),
-            CheckboxField::create(
-                'HideFromReports',
-                _t('SilverStripe\\UserForms\\Model\\EditableFormField\\EditableLiteralField.HIDEFROMREPORT', 'Hide from reports?')
-            )
-        ]);
-
-        return $fields;
+        return parent::getCMSFields();
     }
 
     public function getFormField()

--- a/code/Model/EditableFormField/EditableFormStep.php
+++ b/code/Model/EditableFormField/EditableFormStep.php
@@ -34,11 +34,11 @@ class EditableFormStep extends EditableFormField
      */
     public function getCMSFields()
     {
-        $fields = parent::getCMSFields();
+        $this->beforeUpdateCMSFields(function (FieldList $fields) {
+            $fields->removeByName(['MergeField', 'Default', 'Validation', 'RightTitle']);
+        });
 
-        $fields->removeByName(['MergeField', 'Default', 'Validation', 'RightTitle']);
-
-        return $fields;
+        return parent::getCMSFields();
     }
 
     /**

--- a/code/Model/EditableFormField/EditableLiteralField.php
+++ b/code/Model/EditableFormField/EditableLiteralField.php
@@ -118,25 +118,25 @@ class EditableLiteralField extends EditableFormField
      */
     public function getCMSFields()
     {
-        $fields = parent::getCMSFields();
+        $this->beforeUpdateCMSFields(function (FieldList $fields) {
+            $fields->removeByName(['Default', 'Validation', 'RightTitle']);
 
-        $fields->removeByName(['Default', 'Validation', 'RightTitle']);
+            $fields->addFieldsToTab('Root.Main', [
+                HTMLEditorField::create('Content', _t(__CLASS__.'.CONTENT', 'HTML'))
+                    ->setRows(4)
+                    ->setColumns(20),
+                CheckboxField::create(
+                    'HideFromReports',
+                    _t(__CLASS__.'.HIDEFROMREPORT', 'Hide from reports?')
+                ),
+                CheckboxField::create(
+                    'HideLabel',
+                    _t(__CLASS__.'.HIDELABEL', "Hide 'Title' label on frontend?")
+                )
+            ]);
+        });
 
-        $fields->addFieldsToTab('Root.Main', [
-            HTMLEditorField::create('Content', _t(__CLASS__.'.CONTENT', 'HTML'))
-                ->setRows(4)
-                ->setColumns(20),
-            CheckboxField::create(
-                'HideFromReports',
-                _t(__CLASS__.'.HIDEFROMREPORT', 'Hide from reports?')
-            ),
-            CheckboxField::create(
-                'HideLabel',
-                _t(__CLASS__.'.HIDELABEL', "Hide 'Title' label on frontend?")
-            )
-        ]);
-
-        return $fields;
+        return parent::getCMSFields();
     }
 
     public function getFormField()

--- a/code/Model/EditableFormField/EditableMemberListField.php
+++ b/code/Model/EditableFormField/EditableMemberListField.php
@@ -32,22 +32,22 @@ class EditableMemberListField extends EditableFormField
      */
     public function getCMSFields()
     {
-        $fields = parent::getCMSFields();
+        $this->beforeUpdateCMSFields(function (FieldList $fields) {
+            $fields->removeByName('Default');
+            $fields->removeByName('Validation');
 
-        $fields->removeByName('Default');
-        $fields->removeByName('Validation');
+            /** @skipUpgrade */
+            $fields->addFieldToTab(
+                'Root.Main',
+                DropdownField::create(
+                    'GroupID',
+                    _t('SilverStripe\\UserForms\\Model\\EditableFormField.GROUP', 'Group'),
+                    Group::get()->map()
+                )->setEmptyString(' ')
+            );
+        });
 
-        /** @skipUpgrade */
-        $fields->addFieldToTab(
-            'Root.Main',
-            DropdownField::create(
-                'GroupID',
-                _t('SilverStripe\\UserForms\\Model\\EditableFormField.GROUP', 'Group'),
-                Group::get()->map()
-            )->setEmptyString(' ')
-        );
-
-        return $fields;
+        return parent::getCMSFields();
     }
 
     public function getFormField()

--- a/code/Model/EditableFormField/EditableRadioField.php
+++ b/code/Model/EditableFormField/EditableRadioField.php
@@ -26,11 +26,11 @@ class EditableRadioField extends EditableMultipleOptionField
      */
     public function getCMSFields()
     {
-        $fields = parent::getCMSFields();
+        $this->beforeUpdateCMSFields(function (FieldList $fields) {
+            $fields->removeByName('Default');
+        });
 
-        $fields->removeByName('Default');
-
-        return $fields;
+        return parent::getCMSFields();
     }
 
     public function getFormField()


### PR DESCRIPTION
Some fields in the `EditableFormField` subclasses were not available during updateCMSFields, or were being removed afterwards. Making changes to those fields would have required subclassing, and hiding the original class.