### PR TITLE
BUGFIX: Fixed issue causing the regex on windows to throw an error

### DIFF
--- a/code/Model/Recipient/EmailRecipient.php
+++ b/code/Model/Recipient/EmailRecipient.php
@@ -542,7 +542,7 @@ class EmailRecipient extends DataObject
             $templatePath = substr($absoluteFilename, strlen($prefixToStrip) + 1);
 
             // Optionally remove "templates/" ("templates\" on Windows respectively) prefixes
-            if (preg_match('#(?<=templates' . DIRECTORY_SEPARATOR . ').*$#', $templatePath, $matches)) {
+            if (preg_match('#(?<=templates' . preg_quote(DIRECTORY_SEPARATOR, '#') . ').*$#', $templatePath, $matches)) {
                 $templatePath = $matches[0];
             }
 


### PR DESCRIPTION
This pull request fixes an issue that causes the regex used for getting the template `#(?<=templates' . DIRECTORY_SEPARATOR . ').*$#` to end up escaping the `)` since the resulting expression is `#(?<=templates\).*$#`. This change simply uses `preg_quote()` to properly escape the directory separator.

This was introduced in 0abda421797c7132f9340a5437027e4c5e665054 which appears to only affect the 5.9 release chain.