### PR TITLE
ENH Browser warnings on button click when unsaved data

### DIFF
--- a/code/Extension/UserFormFieldEditorExtension.php
+++ b/code/Extension/UserFormFieldEditorExtension.php
@@ -101,13 +101,13 @@ class UserFormFieldEditorExtension extends DataExtension
                 new GridFieldButtonRow(),
                 (new GridFieldAddClassesButton(EditableTextField::class))
                     ->setButtonName(_t(__CLASS__.'.ADD_FIELD', 'Add Field'))
-                    ->setButtonClass('btn-primary'),
+                    ->setButtonClass('btn-primary discard-confirmation'),
                 (new GridFieldAddClassesButton(EditableFormStep::class))
                     ->setButtonName(_t(__CLASS__.'.ADD_PAGE_BREAK', 'Add Page Break'))
-                    ->setButtonClass('btn-secondary'),
+                    ->setButtonClass('btn-secondary discard-confirmation'),
                 (new GridFieldAddClassesButton([EditableFieldGroup::class, EditableFieldGroupEnd::class]))
                     ->setButtonName(_t(__CLASS__.'.ADD_FIELD_GROUP', 'Add Field Group'))
-                    ->setButtonClass('btn-secondary'),
+                    ->setButtonClass('btn-secondary discard-confirmation'),
                 $editButton = new GridFieldEditButton(),
                 new GridFieldDeleteAction(),
                 new GridFieldToolbarHeader(),


### PR DESCRIPTION
Issue https://github.com/silverstripe/silverstripe-userforms/issues/354

This will trigger a native browser warning when a user clicks `Add Field` / `Add Page Break` / `Add Field Group` button when there's unsaved changes on the form

"Are you sure you want to navigate away from this page ... WARNING your changes have not been saved" (exact depends on browser, it cannot be configured)

All we need to do is add this particular class to the buttons.  It makes use of the existing [jquery.changetracker](https://github.com/silverstripe/silverstripe-admin/blob/1/thirdparty/jquery-changetracker/lib/jquery.changetracker.js) which is used throughout the CMS to detect if a form has changes.  The `.discard-confirmation` class is used [here](https://github.com/silverstripe/silverstripe-admin/blob/c766d10770e04fe54f5fa346d48bd37b2014c025/client/src/legacy/LeftAndMain.js#L1100)

I think this is the right approach because it's a consistent behavior for when a user clicks a regular link instead of a button, such as the `Edit field` icons on the form, or a page in the site tree

I'm really not keen on a localStorage type of solution because then we create a potential new class of state management bugs where we the saved state is out of sync with the form e.g. save the form state to localStorage, navigate around the place, click the back button multiple times, rollback to a previous version of the form etc, localStorage is unaware of all of this.

@clarkepaul are you happy with a "Warning you have unsaved changes" solution when you click one of the "Add" buttons?

