### PR TITLE
Add config option to block jQuery include

### DIFF
--- a/code/Control/UserDefinedFormController.php
+++ b/code/Control/UserDefinedFormController.php
@@ -66,7 +66,9 @@ class UserDefinedFormController extends PageController
 
         // load the jquery
         if (!$page->config()->get('block_default_userforms_js')) {
-            Requirements::javascript('silverstripe/userforms:client/dist/js/jquery.min.js');
+            if (!$page->config()->get('block_userforms_jquery')) {
+                Requirements::javascript('silverstripe/userforms:client/dist/js/jquery.min.js');
+            }
             Requirements::javascript(
                 'silverstripe/userforms:client/dist/js/jquery-validation/jquery.validate.min.js'
             );

--- a/code/UserForm.php
+++ b/code/UserForm.php
@@ -90,6 +90,14 @@ trait UserForm
     private static $block_default_userforms_js = false;
 
     /**
+     * Set this to true to disable automatic inclusion of jQuery
+     * Use to disable jQuery requirment if site already includes it
+     * @config
+     * @var bool
+     */
+    private static $block_userforms_jquery = false;
+
+    /**
      * @var array Fields on the user defined form page.
      */
     private static $db = [


### PR DESCRIPTION
Adds the ability to disable the inclusion of jQuery (while keeping the other javascript files) for use on sites that already have jQuery included in the theme.

Without this option, 2 copies of jQuery end up getting included on the page, which breaks features such as javascript validation when using nocaptcha: https://github.com/UndefinedOffset/silverstripe-nocaptcha/issues/66#issuecomment-902562063