### PR TITLE
Additional data passed to `updateAfterProcess` hook

### DIFF
--- a/code/Control/UserDefinedFormController.php
+++ b/code/Control/UserDefinedFormController.php
@@ -447,7 +447,7 @@ JS
             }
         }
 
-        $submittedForm->extend('updateAfterProcess');
+        $submittedForm->extend('updateAfterProcess', $emailData, $attachments);
 
         $session = $this->getRequest()->getSession();
         $session->clear("FormInfo.{$form->FormName()}.errors");


### PR DESCRIPTION
I got an interesting use case which is to delete the uploaded files after the email has been sent or in relation to disable form submissions but still attaching files to the emails being sent. 

In this case, passing the `$attachments` array to the existing hook, `updateAfterProcess` which suffice and I will be able to create an extension to do implementation.

Added `$emailData` in the arguments as well in similar fashion with extension hook before sending the emails called, `updateEmailData`.

```
public function process($data, $form)
{
...
$this->extend('updateEmailData', $emailData, $attachments);

foreach ($recipients as $recipient) {
    // Create email
    // Add data and file attachments
    // Send email
}

// Passing additional data and attachments just like above
$submittedForm->extend('updateAfterProcess', $emailData, $attachments);
...
}
```


Let me know your thoughts about this.