### PR TITLE
Protect uploads if folder for EditableFileField was removed

### DIFF
--- a/code/Model/EditableFormField/EditableFileField.php
+++ b/code/Model/EditableFormField/EditableFileField.php
@@ -194,7 +194,18 @@ class EditableFileField extends EditableFormField
         return $result;
     }
 
+    public function getFolderExists(): bool
+    {
+        return $this->Folder()->ID !== 0;
+    }
 
+    public function createProtectedFolder(): void
+    {
+        $folderName = sprintf('page-%d/upload-field-%d', $this->ParentID, $this->ID);
+        $folder = UserDefinedFormAdmin::getFormSubmissionFolder($folderName);
+        $this->FolderID = $folder->ID;
+        $this->write();
+    }
 
     public function getFormField()
     {

--- a/tests/php/Model/EditableFormFieldTest.php
+++ b/tests/php/Model/EditableFormFieldTest.php
@@ -169,6 +169,51 @@ class EditableFormFieldTest extends FunctionalTest
     }
 
     /**
+     * Test that if folder is not set or folder was removed,
+     * then getFormField() saves file in protected folder
+     */
+    public function testCreateProtectedFolder()
+    {
+        $fileField1 = $this->objFromFixture(EditableFileField::class, 'file-field-without-folder');
+        $fileField2 = $this->objFromFixture(EditableFileField::class, 'file-field-with-folder');
+
+        $fileField1->createProtectedFolder();
+
+        $formField1 = $fileField1->getFormField();
+        $formField2 = $fileField2->getFormField();
+
+        $canViewParent1 = $fileField1->Folder()->Parent()->Parent()->CanViewType;
+        $canViewParent2 = $fileField2->Folder()->Parent()->CanViewType;
+
+        $this->assertEquals('OnlyTheseUsers', $canViewParent1);
+        $this->assertEquals('Inherit', $canViewParent2);
+
+        $this->assertTrue(
+            (bool) preg_match(
+                sprintf(
+                    '/^Form-submissions\/page-%d\/upload-field-%d/',
+                    $fileField1->ParentID,
+                    $fileField1->ID
+                ),
+                $formField1->folderName,
+            )
+        );
+        $this->assertEquals('folder1/folder1-1/', $formField2->folderName);
+    }
+
+    /**
+     * Verify that folder is related to a field exist
+     */
+    public function testGetFolderExists()
+    {
+        $fileField1 = $this->objFromFixture(EditableFileField::class, 'file-field-without-folder');
+        $fileField2 = $this->objFromFixture(EditableFileField::class, 'file-field-with-folder');
+        
+        $this->assertFalse($fileField1->getFolderExists());
+        $this->assertTrue($fileField2->getFolderExists());
+    }
+
+    /**
      * Verify that unique names are automatically generated for each formfield
      */
     public function testUniqueName()

--- a/tests/php/Model/EditableFormFieldTest.yml
+++ b/tests/php/Model/EditableFormFieldTest.yml
@@ -2,6 +2,13 @@ SilverStripe\Security\Group:
   admin:
     Title: Administrators
 
+SilverStripe\Assets\Folder:
+  user-form-folder-parent:
+    Title: folder1
+  user-form-folder-child:
+    Title: folder1-1
+    Parent: =>SilverStripe\Assets\Folder.user-form-folder-parent
+
 SilverStripe\UserForms\Model\EditableFormField\EditableTextField:
   basic-text:
     Name: basic_text_name
@@ -289,6 +296,14 @@ SilverStripe\UserForms\Model\EditableFormField\EditableFileField:
   file-field:
     Name: file-uploader
     Title: Set file
+  file-field-without-folder:
+    Name: file-uploader-without-folder
+    Title: Set file
+    FolderID: 0
+  file-field-with-folder:
+    Name: file-uploader-with-folder
+    Title: Set file
+    FolderID: =>SilverStripe\Assets\Folder.user-form-folder-child
 
 SilverStripe\UserForms\Model\UserDefinedForm:
   basic-form-page:

--- a/tests/php/UserFormsTest.yml
+++ b/tests/php/UserFormsTest.yml
@@ -275,6 +275,10 @@ SilverStripe\UserForms\Model\EditableFormField\EditableFileField:
   file-field-2:
     Name: FileUploadField
     Title: File Upload Field
+  file-field-3:
+    Name: FileUploadField
+    Title: File Upload Field Without Folder
+    Folder: ''
 
 SilverStripe\UserForms\Model\EditableFormField\EditableFieldGroupEnd:
   group1end:
@@ -494,6 +498,11 @@ SilverStripe\UserForms\Model\UserDefinedForm:
     EmailRecipients:
       - =>SilverStripe\UserForms\Model\Recipient\EmailRecipient.upload-recipient
       - =>SilverStripe\UserForms\Model\Recipient\EmailRecipient.upload-no-data
+
+  upload-form-without-folder:
+    Title: 'Form with upload field without folder'
+    Fields:
+      - =>SilverStripe\UserForms\Model\EditableFormField\EditableFileField.file-field-3
 
 SilverStripe\UserForms\Model\EditableCustomRule:
   rule1:


### PR DESCRIPTION
### Description
- Two new methods (getFolderExists(), createProtectedFolder() ) were added in EditableFileField class. 
- To save submitted files in Draft stage (by default) or in custom stage (if user configures "file_upload_stage") Version support was added in process method of UserDefinedFormController class.
- Tests coverage for new functionality. 

### Parent issue 
- silverstripe/silverstripe-userforms#1135