### PR TITLE
DEP Require a minimum version of segment field that installs in the vendor folder

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -34,7 +34,7 @@
         "silverstripe/framework": "^4.10",
         "silverstripe/cms": "^4.6",
         "symbiote/silverstripe-gridfieldextensions": "^3.1",
-        "silverstripe/segment-field": "^2.0",
+        "silverstripe/segment-field": "^2.2",
         "silverstripe/versioned": "^1.0",
         "silverstripe/mimevalidator": "^2.0"
     },


### PR DESCRIPTION
Issue https://github.com/silverstripe/github-actions-ci-cd/issues/33

Causes --prefer-lowest build to fail