### PR TITLE
MNT Explicitly set class for test polymorphic has_one

### DIFF
--- a/tests/php/Form/GridFieldAddClassesButtonTest.php
+++ b/tests/php/Form/GridFieldAddClassesButtonTest.php
@@ -34,7 +34,11 @@ class GridFieldAddClassesButtonTest extends SapphireTest
         $controller->setCurrentPageID($udf->ID);
         $controller->pushCurrent();
         $list = new DataList(EditableFormField::class);
-        $field = EditableTextField::create(['ParentID' => $udfID, 'Title' => 'MyTitle']);
+        $field = EditableTextField::create([
+            'ParentClass' => UserDefinedForm::class,
+            'ParentID' => $udfID,
+            'Title' => 'MyTitle',
+        ]);
         $fieldID = $field->write();
         $list->add($field);
         $gridField = new GridField('MyName', 'MyTitle', $list);


### PR DESCRIPTION
A new test was added in #1146 that didn't explicitly declare a class for a polymorphic has_one. This has caused a failed CI build for recipe-kitchen-sink.

## Parent issue
- https://github.com/silverstripeltd/product-issues/issues/549