### PR TITLE
FIX MAX_FILE_SIZE of the last EditableFileField

### DIFF
--- a/code/Model/EditableFormField/EditableFileField.php
+++ b/code/Model/EditableFormField/EditableFileField.php
@@ -201,7 +201,7 @@ class EditableFileField extends EditableFormField
         $field = FileField::create($this->Name, $this->Title ?: false)
             ->setFieldHolderTemplate(EditableFormField::class . '_holder')
             ->setTemplate(__CLASS__)
-            ->setValidator(Injector::inst()->get(Upload_Validator::class . '.userforms'));
+            ->setValidator(Injector::inst()->get(Upload_Validator::class . '.userforms', false));
 
         $field->setFieldHolderTemplate(EditableFormField::class . '_holder')
             ->setTemplate(__CLASS__);


### PR DESCRIPTION
## Description
Added second parameters `false` to `Injector::inst()->get(Upload_Validator::class . '.userforms', false)` to avoid using singleton of Upload_Validator for all FileField.

## Parent issue
- #1127 