### PR TITLE
MNT Use GitHub Actions CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,16 @@
+name: CI
+
+on:
+  push:
+  pull_request:
+  workflow_dispatch:
+  # Every Saturday at 12:30pm UTC
+  schedule:
+    - cron: '30 12 * * 6'
+
+jobs:
+  ci:
+    name: CI
+    # Only run cron on the silverstripe account
+    if: (github.event_name == 'schedule' && startsWith(github.repository, 'silverstripe/')) || (github.event_name != 'schedule')
+    uses: silverstripe/gha-ci/.github/workflows/ci.yml@v1

--- a/.github/workflows/keepalive.yml
+++ b/.github/workflows/keepalive.yml
@@ -1,0 +1,17 @@
+name: Keepalive
+
+on:
+  workflow_dispatch:
+  # The 4th of every month at 10:50am UTC
+  schedule:
+    - cron: '50 10 4 * *'
+
+jobs:
+  keepalive:
+    name: Keepalive
+    # Only run cron on the silverstripe account
+    if: (github.event_name == 'schedule' && startsWith(github.repository, 'silverstripe/')) || (github.event_name != 'schedule')
+    runs-on: ubuntu-latest
+    steps:
+      - name: Keepalive
+        uses: silverstripe/gha-keepalive@v1

--- a/composer.json
+++ b/composer.json
@@ -34,13 +34,16 @@
         "silverstripe/framework": "^4.10",
         "silverstripe/cms": "^4.6",
         "symbiote/silverstripe-gridfieldextensions": "^3.1",
-        "silverstripe/segment-field": "^2.0",
+        "silverstripe/segment-field": "^2.2",
         "silverstripe/versioned": "^1.0",
         "silverstripe/mimevalidator": "^2.0"
     },
     "require-dev": {
         "phpunit/phpunit": "^9.5",
         "squizlabs/php_codesniffer": "^3.0"
+    },
+    "conflict": {
+        "egulias/email-validator": "^2"
     },
     "autoload": {
         "psr-4": {

--- a/readme.md
+++ b/readme.md
@@ -3,7 +3,7 @@
 UserForms enables CMS users to create dynamic forms via a drag and drop interface
 and without getting involved in any PHP code.
 
-[![Build Status](https://api.travis-ci.com/silverstripe/silverstripe-userforms.svg?branch=5)](https://travis-ci.com/silverstripe/silverstripe-userforms)
+[![CI](https://github.com/silverstripe/silverstripe-userforms/actions/workflows/ci.yml/badge.svg)](https://github.com/silverstripe/silverstripe-userforms/actions/workflows/ci.yml)
 [![Scrutinizer Code Quality](https://scrutinizer-ci.com/g/silverstripe/silverstripe-userforms/badges/quality-score.png?b=master)](https://scrutinizer-ci.com/g/silverstripe/silverstripe-userforms/?branch=master)
 [![codecov](https://codecov.io/gh/silverstripe/silverstripe-userforms/branch/master/graph/badge.svg)](https://codecov.io/gh/silverstripe/silverstripe-userforms)
 [![SilverStripe supported module](https://img.shields.io/badge/silverstripe-supported-0071C4.svg)](https://www.silverstripe.org/software/addons/silverstripe-commercially-supported-module-list/)


### PR DESCRIPTION
Issue https://github.com/silverstripe/gha-ci/issues/11<br /><br />Workflow run https://github.com/creative-commoners/silverstripe-userforms/actions?query=branch%3Apulls%2F5.12%2Fmodule-standards

Setting segment-field to ^2.2 for --prefer-lowest as it's the minimum version version where it's a 'vendor-module' in composer.json rather than a 'silverstripe-module', meaning it gets loaded in to the vendor folder, so the gha-ci will delete its phpunit5 tests otherwise we get

```
PHP Fatal error:  Declaration of SilverStripe\Forms\Tests\SegmentFieldTest::tearDown() must be compatible with SilverStripe\Dev\SapphireTest::tearDown(): void in /home/runner/work/silverstripe-userforms/silverstripe-userforms/segment-field/tests/SegmentFieldTest.php on line 23
```
https://github.com/creative-commoners/silverstripe-userforms/runs/7191559893?check_suite_focus=true