### PR TITLE
DEP Ensure phpunit9 compatible version of segment-field

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -34,7 +34,7 @@
         "silverstripe/framework": "^4.10",
         "silverstripe/cms": "^4.6",
         "symbiote/silverstripe-gridfieldextensions": "^3.1",
-        "silverstripe/segment-field": "^2.0",
+        "silverstripe/segment-field": "^2.2",
         "silverstripe/versioned": "^1.0",
         "silverstripe/mimevalidator": "^2.0"
     },


### PR DESCRIPTION
Issue https://github.com/silverstripe/gha-ci/issues/37

Match what's on the 5.13 branch - looks like this was missed on mergeup

Fix https://github.com/silverstripe/silverstripe-userforms/runs/7491412617?check_suite_focus=true#step:12:62
`PHP Fatal error:  Declaration of SilverStripe\Forms\Tests\SegmentFieldTest::tearDown() must be compatible with SilverStripe\Dev\SapphireTest::tearDown(): void in /home/runner/work/silverstripe-userforms/silverstripe-userforms/segment-field/tests/SegmentFieldTest.php on line 23`