### PR TITLE
ENH Protect access to the uploaded file without permission

### DIFF
--- a/code/Model/Submission/SubmittedFileField.php
+++ b/code/Model/Submission/SubmittedFileField.php
@@ -39,16 +39,26 @@ class SubmittedFileField extends SubmittedFormField
     public function getFormattedValue()
     {
         $name = $this->getFileName();
-        $link = $this->getLink();
+        $link = $this->getLink(false);
         $title = _t(__CLASS__ . '.DOWNLOADFILE', 'Download File');
+        $message = _t(__CLASS__ . '.INSUFFICIENTRIGHTS', 'You don\'t have the right permissions to download this file');
+        $file = $this->getUploadedFileFromDraft();
 
         if ($link) {
-            return DBField::create_field('HTMLText', sprintf(
-                '%s - <a href="%s" target="_blank">%s</a>',
-                $name,
-                $link,
-                $title
-            ));
+            if ($file->canView()) {
+                return DBField::create_field('HTMLText', sprintf(
+                    '%s - <a href="%s" target="_blank">%s</a>',
+                    htmlspecialchars($name),
+                    htmlspecialchars($link),
+                    htmlspecialchars($title)
+                ));
+            } else {
+                return DBField::create_field('HTMLText', sprintf(
+                    '<i class="icon font-icon-lock"></i> %s - <em>%s</em>',
+                    htmlspecialchars($name),
+                    htmlspecialchars($message)
+                ));
+            }
         }
 
         return false;
@@ -69,11 +79,11 @@ class SubmittedFileField extends SubmittedFormField
      *
      * @return string
      */
-    public function getLink()
+    public function getLink($grant = true)
     {
         if ($file = $this->getUploadedFileFromDraft()) {
             if ($file->exists()) {
-                return $file->getAbsoluteURL();
+                return $file->getURL($grant);
             }
         }
     }

--- a/lang/en.yml
+++ b/lang/en.yml
@@ -246,6 +246,7 @@ en:
     SINGULARNAME: 'Email Recipient Condition'
   SilverStripe\UserForms\Model\Submission\SubmittedFileField:
     DOWNLOADFILE: 'Download File'
+    INSUFFICIENTRIGHTS: 'You don''t have the right permissions to download this file'
     PLURALNAME: 'Submitted File Fields'
     PLURALS:
       one: 'A Submitted File Field'

--- a/tests/php/Model/SubmittedFileFieldTest.php
+++ b/tests/php/Model/SubmittedFileFieldTest.php
@@ -4,6 +4,8 @@ namespace SilverStripe\UserForms\Tests\Model;
 
 use SilverStripe\Assets\Dev\TestAssetStore;
 use SilverStripe\Assets\File;
+use SilverStripe\Assets\Storage\AssetStore;
+use SilverStripe\Core\Injector\Injector;
 use SilverStripe\Dev\SapphireTest;
 use SilverStripe\UserForms\Model\Submission\SubmittedFileField;
 use SilverStripe\UserForms\Model\Submission\SubmittedForm;
@@ -11,11 +13,27 @@ use SilverStripe\Versioned\Versioned;
 
 class SubmittedFileFieldTest extends SapphireTest
 {
+    protected $file;
+    protected $submittedForm;
+
     protected function setUp(): void
     {
         parent::setUp();
 
         TestAssetStore::activate('SubmittedFileFieldTest');
+
+        $this->file = File::create();
+        $this->file->setFromString('ABC', 'test-SubmittedFileFieldTest.txt');
+        $this->file->write();
+
+        $this->submittedForm = SubmittedForm::create();
+        $this->submittedForm->write();
+
+        $this->submittedFile = SubmittedFileField::create();
+        $this->submittedFile->UploadedFileID = $this->file->ID;
+        $this->submittedFile->Name = 'File';
+        $this->submittedFile->ParentID = $this->submittedForm->ID;
+        $this->submittedFile->write();
     }
 
     protected function tearDown(): void
@@ -27,23 +45,10 @@ class SubmittedFileFieldTest extends SapphireTest
 
     public function testDeletingSubmissionRemovesFile()
     {
-        $file = File::create();
-        $file->setFromString('ABC', 'test-SubmittedFileFieldTest.txt');
-        $file->write();
+        $this->assertStringContainsString('test-SubmittedFileFieldTest', $this->submittedFile->getFileName(), 'Submitted file is linked');
 
-        $submittedForm = SubmittedForm::create();
-        $submittedForm->write();
-
-        $submittedFile = SubmittedFileField::create();
-        $submittedFile->UploadedFileID = $file->ID;
-        $submittedFile->Name = 'File';
-        $submittedFile->ParentID = $submittedForm->ID;
-        $submittedFile->write();
-
-        $this->assertStringContainsString('test-SubmittedFileFieldTest', $submittedFile->getFileName(), 'Submitted file is linked');
-
-        $submittedForm->delete();
-        $fileId = $file->ID;
+        $this->submittedForm->delete();
+        $fileId = $this->file->ID;
 
         $draftVersion = Versioned::withVersionedMode(function () use ($fileId) {
             Versioned::set_stage(Versioned::DRAFT);
@@ -60,5 +65,37 @@ class SubmittedFileFieldTest extends SapphireTest
         });
 
         $this->assertNull($liveVersion, 'Live file has been deleted');
+    }
+
+    public function testGetFormattedValue()
+    {
+        $fileName = $this->submittedFile->getFileName();
+
+        $this->file->CanViewType = 'OnlyTheseUsers';
+        $this->file->write();
+        
+        $this->loginWithPermission('ADMIN');
+        $this->assertEquals(
+            sprintf(
+                '%s - <a href="/assets/3c01bdbb26/test-SubmittedFileFieldTest.txt" target="_blank">Download File</a>',
+                $fileName
+            ),
+            $this->submittedFile->getFormattedValue()->value
+        );
+            
+        $this->loginWithPermission('CMS_ACCESS_CMSMain');
+        $this->assertEquals(
+            sprintf(
+                '<i class="icon font-icon-lock"></i> %s - <em>You don\'t have the right permissions to download this file</em>',
+                $fileName
+            ),
+            $this->submittedFile->getFormattedValue()->value
+        );
+
+        $store = Injector::inst()->get(AssetStore::class);
+        $this->assertFalse(
+            $store->canView($fileName, $this->file->getHash()),
+            'Users without canView rights on the file should not have been session granted access to it'
+        );
     }
 }


### PR DESCRIPTION
### Description
- Hide a link to the uploaded file from a user which doesn't have access to the file.
- Show name of the uploaded file for all users.
- Developer has an ability to provide automatically granted access to the submitted file by adding extensions SubmittedFileFieldExtension to the SubmittedFileField class.

User will see a message, that he doesn't have enough permissions to view or download the submitted file. 

![Screen Shot 2022-08-18 at 2 43 00 PM](https://user-images.githubusercontent.com/87288324/185283869-80202f45-e3ec-4dae-89f7-ae9bd7787e4a.png)


### Parent issue
- https://github.com/silverstripe/silverstripe-userforms/issues/1158