### PR TITLE
ENH Protect access to the uploaded file without permission

### DIFF
--- a/code/Model/Submission/SubmittedFileField.php
+++ b/code/Model/Submission/SubmittedFileField.php
@@ -39,16 +39,26 @@ class SubmittedFileField extends SubmittedFormField
     public function getFormattedValue()
     {
         $name = $this->getFileName();
-        $link = $this->getLink();
+        $link = $this->getLink(false);
         $title = _t(__CLASS__ . '.DOWNLOADFILE', 'Download File');
+        $message = _t(__CLASS__ . '.INSUFFICIENTRIGHTS', 'You don\'t have the right permissions to download this file');
+        $file = $this->getUploadedFileFromDraft();
 
         if ($link) {
-            return DBField::create_field('HTMLText', sprintf(
-                '%s - <a href="%s" target="_blank">%s</a>',
-                $name,
-                $link,
-                $title
-            ));
+            if ($file->canView()) {
+                return DBField::create_field('HTMLText', sprintf(
+                    '%s - <a href="%s" target="_blank">%s</a>',
+                    htmlspecialchars($name, ENT_QUOTES),
+                    htmlspecialchars($link, ENT_QUOTES),
+                    htmlspecialchars($title, ENT_QUOTES)
+                ));
+            } else {
+                return DBField::create_field('HTMLText', sprintf(
+                    '<i class="icon font-icon-lock"></i> %s - <em>%s</em>',
+                    htmlspecialchars($name, ENT_QUOTES),
+                    htmlspecialchars($message, ENT_QUOTES)
+                ));
+            }
         }
 
         return false;
@@ -69,11 +79,11 @@ class SubmittedFileField extends SubmittedFormField
      *
      * @return string
      */
-    public function getLink()
+    public function getLink($grant = true)
     {
         if ($file = $this->getUploadedFileFromDraft()) {
             if ($file->exists()) {
-                return $file->getAbsoluteURL();
+                return $file->getURL($grant);
             }
         }
     }

--- a/lang/en.yml
+++ b/lang/en.yml
@@ -246,6 +246,7 @@ en:
     SINGULARNAME: 'Email Recipient Condition'
   SilverStripe\UserForms\Model\Submission\SubmittedFileField:
     DOWNLOADFILE: 'Download File'
+    INSUFFICIENTRIGHTS: 'You don''t have the right permissions to download this file'
     PLURALNAME: 'Submitted File Fields'
     PLURALS:
       one: 'A Submitted File Field'


### PR DESCRIPTION
### Description
- Hide a link to the uploaded file from a user which doesn't have access to the file.
- Show name of the uploaded file for all users.
- Developer has an ability to provide automatically granted access to the submitted file by adding extensions SubmittedFileFieldExtension to the SubmittedFileField class.

User will see a message, that he doesn't have enough permissions to view or download the submitted file. 

![Screen Shot 2022-08-18 at 2 43 00 PM](https://user-images.githubusercontent.com/87288324/185283869-80202f45-e3ec-4dae-89f7-ae9bd7787e4a.png)


### Parent issue
- https://github.com/silverstripe/silverstripe-userforms/issues/1158