### PR TITLE
FIX submission performance issues with large data

### DIFF
--- a/code/Model/EditableFormField.php
+++ b/code/Model/EditableFormField.php
@@ -145,6 +145,10 @@ class EditableFormField extends DataObject
         'ShowOnLoad' => true,
     ];
 
+    private static $indexes = [
+        'Name' => 'Name',
+    ];
+
 
     /**
      * @config

--- a/code/Model/Submission/SubmittedFormField.php
+++ b/code/Model/Submission/SubmittedFormField.php
@@ -34,6 +34,10 @@ class SubmittedFormField extends DataObject
 
     private static $table_name = 'SubmittedFormField';
 
+    private static $indexes = [
+        'Name' => 'Name',
+    ];
+
     /**
      * @param Member $member
      * @param array $context


### PR DESCRIPTION
The more submissions a form receives, the more submission fields it must process just to be able to load `getCMSFields`. Arguably submission data does not belong here, but this is beyond the scope of this patch.

On popular forms it is not improbable to be trying to process 300,000 submitted fields just to test the unique sets of name and title... however databases have the ability to do this without wasting PHP cycles and memory, leaving us with a much smaller set to process and hopefully bypassing one (of several) performance issues with this module.

The consequence of not making allowance for this is that a page in the CMS suddenly stops saving or loading via web server or PHP (or both) process timeouts (e.g. saving takes longer than 30 seconds so saving never happens).

---

What did I do?

- added indexes to the fields being selected, joined, and filtered on
- moved PHP replacement of `.` with ` ` to SQL query to save hundreds of thousands of PHP loop cycles.

Inconsequential changes, but show heavily in the diff:

- Moved submissions field creation to its own method
- indentation level changed so all shows as new (but it's mostly not)
- formatted the SQL a little nicer
- as above the foreach loop is gone
- everything else is the same