### PR TITLE
Fix incorrect label on unwritten field groups

### DIFF
--- a/code/Model/EditableFormField/EditableFieldGroupEnd.php
+++ b/code/Model/EditableFormField/EditableFieldGroupEnd.php
@@ -5,7 +5,6 @@ namespace SilverStripe\UserForms\Model\EditableFormField;
 use SilverStripe\Forms\FieldList;
 use SilverStripe\Forms\HiddenField;
 use SilverStripe\Forms\LabelField;
-use SilverStripe\Security\Group;
 use SilverStripe\UserForms\Model\EditableFormField;
 
 /**
@@ -44,7 +43,7 @@ class EditableFieldGroupEnd extends EditableFormField
             __CLASS__.'.FIELD_GROUP_END',
             '{group} end',
             [
-                'group' => ($group && $group->exists()) ? $group->CMSTitle : Group::class
+                'group' => ($group && $group->exists()) ? $group->CMSTitle : 'Group'
             ]
         );
     }


### PR DESCRIPTION
I imagine this was as a result of the upgrader tool assuming `'Group'` referred to a class name