### PR TITLE
FIX: EditableLiteralField enabling 'Hide 'Title' label on frontend?' causes nolabel

### DIFF
--- a/code/Model/EditableFormField/EditableLiteralField.php
+++ b/code/Model/EditableFormField/EditableLiteralField.php
@@ -161,7 +161,7 @@ class EditableLiteralField extends EditableFormField
         parent::updateFormField($field);
 
         if ($this->HideLabel) {
-            $this->ExtraClass .= ' nolabel';
+            $field->addExtraClass('nolabel');
         } else {
             $field->setTitle($this->Title);
         }


### PR DESCRIPTION
…es nolabel to be written twice for every write #1132

https://github.com/silverstripe/silverstripe-userforms/issues/1132 a PR from JamesDPC suggested fix