### PR TITLE
FIX: Submissions gridfield could pull columns from the wrong parent object when using polymorphism

### DIFF
--- a/code/UserForm.php
+++ b/code/UserForm.php
@@ -3,6 +3,7 @@
 namespace SilverStripe\UserForms;
 
 use Colymba\BulkManager\BulkManager;
+use SilverStripe\Core\Convert;
 use SilverStripe\Core\Injector\Injector;
 use SilverStripe\Forms\CheckboxField;
 use SilverStripe\Forms\CompositeField;
@@ -269,6 +270,7 @@ trait UserForm
         // view the submissions
         // make sure a numeric not a empty string is checked against this int column for SQL server
         $parentID = (!empty($this->ID)) ? (int) $this->ID : 0;
+        $parentClass = Convert::raw2sql(get_class($this));
 
         // get a list of all field names and values used for print and export CSV views of the GridField below.
         $columnSQL = <<<SQL
@@ -279,8 +281,8 @@ SELECT DISTINCT
 FROM "SubmittedFormField"
   LEFT JOIN "SubmittedForm" ON "SubmittedForm"."ID" = "SubmittedFormField"."ParentID"
   LEFT JOIN "EditableFormField" ON "EditableFormField"."Name" = "SubmittedFormField"."Name"
-WHERE "SubmittedForm"."ParentID" = '$parentID'
-  AND "EditableFormField"."ParentID" = '$parentID'
+WHERE "SubmittedForm"."ParentID" = '$parentID' AND "SubmittedForm"."ParentClass" = '$parentClass'
+  AND "EditableFormField"."ParentID" = '$parentID' AND "EditableFormField"."ParentClass" = '$parentClass'
 ORDER BY "Sort", "Title"
 SQL;
 
@@ -307,7 +309,7 @@ SQL;
             'LastEdited' => 'Last Edited'
         );
 
-        foreach (EditableFormField::get()->filter(['ParentID' => $parentID, 'ShowInSummary' => 1]) as $eff) {
+        foreach (EditableFormField::get()->filter(['ParentID' => $parentID, 'ParentClass' => get_class($this), 'ShowInSummary' => 1]) as $eff) {
             $summaryarray[$eff->Name] = $eff->Title ?: $eff->Name;
         }
 

--- a/tests/php/Model/SubClassFormTest.php
+++ b/tests/php/Model/SubClassFormTest.php
@@ -1,0 +1,53 @@
+<?php
+
+namespace SilverStripe\UserForms\Tests\Model;
+
+use SilverStripe\Control\Email\Email;
+use SilverStripe\Dev\FunctionalTest;
+use SilverStripe\Forms\GridField\GridField;
+use SilverStripe\Forms\GridField\GridFieldDataColumns;
+use SilverStripe\UserForms\Extension\UserFormFieldEditorExtension;
+use SilverStripe\UserForms\Model\UserDefinedForm;
+use SilverStripe\UserForms\Tests\Model\SubClassFormTest\SubClassForm;
+
+/**
+ * @package userforms
+ */
+class SubClassFormTest extends FunctionalTest
+{
+    protected $usesTransactions = false;
+
+    protected static $fixture_file = 'SubClassFormTest.yml';
+
+    protected static $required_extensions = [
+        UserDefinedForm::class => [UserFormFieldEditorExtension::class],
+    ];
+
+    protected static $extra_dataobjects = [
+        SubClassForm::class,
+    ];
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        Email::config()->update('admin_email', 'no-reply@example.com');
+    }
+
+    public function testGetCMSFieldsShowInSummary()
+    {
+        $this->logInWithPermission('ADMIN');
+        $form = $this->objFromFixture(SubClassForm::class, 'summary-rules-form');
+
+        $fields = $form->getCMSFields();
+
+        $this->assertInstanceOf(GridField::class, $fields->dataFieldByName('Submissions'));
+
+        $submissionsgrid = $fields->dataFieldByName('Submissions');
+        $gridFieldDataColumns = $submissionsgrid->getConfig()->getComponentByType(GridFieldDataColumns::class);
+
+        $summaryFields = $gridFieldDataColumns->getDisplayFields($submissionsgrid);
+
+        $this->assertContains('SummaryShow', array_keys($summaryFields ?? []), 'Summary field not showing displayed field');
+        $this->assertNotContains('SummaryHide', array_keys($summaryFields ?? []), 'Summary field showing displayed field');
+    }
+}

--- a/tests/php/Model/SubClassFormTest.yml
+++ b/tests/php/Model/SubClassFormTest.yml
@@ -1,0 +1,17 @@
+SilverStripe\UserForms\Model\EditableFormField\EditableTextField:
+  summary-show:
+    Name: SummaryShow
+    Title: Summary Text Field
+    ShowInSummary: true
+
+  summary-hide:
+    Name: SummaryHide
+    Title: Summary Text Field
+    ShowInSummary: false
+
+SilverStripe\UserForms\Tests\Model\SubClassFormTest\SubClassForm:
+  summary-rules-form:
+    Title: Summary Fields Form
+    Fields:
+      - =>SilverStripe\UserForms\Model\EditableFormField\EditableTextField.summary-show
+      - =>SilverStripe\UserForms\Model\EditableFormField\EditableTextField.summary-hide

--- a/tests/php/Model/SubClassFormTest/SubClassForm.php
+++ b/tests/php/Model/SubClassFormTest/SubClassForm.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace SilverStripe\UserForms\Tests\Model\SubClassFormTest;
+
+use SilverStripe\Dev\TestOnly;
+use SilverStripe\UserForms\Model\UserDefinedForm;
+
+class SubClassForm extends UserDefinedForm implements TestOnly
+{
+    private static $table_name = 'SubClassForm';
+}


### PR DESCRIPTION
Where the parent relationship is a polymorphic relationship the raw query used to figure out what fields should be shown in the columns technically allows for matching with the wrong parent object since the query only matches the `ParentID` field and does not include matching the `ParentClass` ([see here](https://github.com/silverstripe/silverstripe-userforms/blob/5.14.0/code/UserForm.php#L282-L283)).

This is present in multiple versions but this pull request is based on the 5.14 branch.

The one thing I'm not 100% sure on with this pull request is what the value of `ParentClass` would be if the parent is a sub-class of the object using the `UserForm` trait.