### PR TITLE
MNT Broken builds

### DIFF
--- a/tests/php/Model/Recipient/EmailRecipientTest.php
+++ b/tests/php/Model/Recipient/EmailRecipientTest.php
@@ -20,13 +20,13 @@ class EmailRecipientTest extends SapphireTest
         $recipient->EmailBodyHtml = '<p>Some email content. About us: [sitetree_link,id=' . $page->ID . '].</p>';
 
         $result = $recipient->getEmailBodyContent();
-        $this->assertStringContainsString('/about-us/', $result);
+        $this->assertStringContainsString('/about-us', $result);
 
         $recipient->SendPlain = true;
         $recipient->EmailBody = 'Some email content. About us: [sitetree_link,id=' . $page->ID . '].';
 
         $result = $recipient->getEmailBodyContent();
-        $this->assertStringContainsString('/about-us/', $result);
+        $this->assertStringContainsString('/about-us', $result);
     }
 
     public function testEmptyRecipientFailsValidation()


### PR DESCRIPTION
Issue https://github.com/silverstripeltd/product-issues/issues/659

Fixes https://github.com/silverstripe/recipe-kitchen-sink/actions/runs/3990680546/jobs/6844618723#step:12:70
`1) SilverStripe\UserForms\Tests\Model\Recipient\EmailRecipientTest::testShortcodesAreRenderedInEmailPreviewContent
Failed asserting that '<p>Some email content. About us: /about-us.</p>' contains "/about-us/".`

Broken behat tests will be fixed as part of https://github.com/silverstripeltd/product-issues/issues/644