### PR TITLE
MNT Revert erroneous dependency changes

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -31,12 +31,12 @@
     ],
     "require": {
         "php": "^7.4 || ^8.0",
-        "silverstripe/framework": "4.13.x-dev",
-        "silverstripe/cms": "4.13.x-dev",
+        "silverstripe/framework": "^4.10",
+        "silverstripe/cms": "^4.6",
         "symbiote/silverstripe-gridfieldextensions": "^3.1",
-        "silverstripe/segment-field": "2.8.x-dev",
-        "silverstripe/versioned": "1.13.x-dev",
-        "silverstripe/mimevalidator": "2.5.x-dev"
+        "silverstripe/segment-field": "^2.2",
+        "silverstripe/versioned": "^1.0",
+        "silverstripe/mimevalidator": "^2.0"
     },
     "require-dev": {
         "phpunit/phpunit": "^9.5",


### PR DESCRIPTION
Bad logic in cow resulted in many non-recipes having their constraints updated automatically when the beta was released.

## Issue
- https://github.com/silverstripe/.github/issues/33