### PR TITLE
FIX Passing array to setReplyTo method instead of string

### DIFF
--- a/code/Control/UserDefinedFormController.php
+++ b/code/Control/UserDefinedFormController.php
@@ -433,15 +433,17 @@ JS
                     $submittedFormField = $submittedFields->find('Name', $recipient->SendEmailFromField()->Name);
 
                     if ($submittedFormField && $submittedFormField->Value && is_string($submittedFormField->Value)) {
-                        $email->setReplyTo(explode(',', $submittedFormField->Value ?? ''));
+                        $emailSendTo = $this->validEmailsToArray($submittedFormField->Value);
+                        $email->addReplyTo(...$emailSendTo);
                     }
                 } elseif ($recipient->EmailReplyTo) {
-                    $email->setReplyTo(explode(',', $recipient->EmailReplyTo ?? ''));
+                    $emailReplyTo = $this->validEmailsToArray($recipient->EmailReplyTo);
+                    $email->addReplyTo(...$emailReplyTo);
                 }
 
                 // check for a specified from; otherwise fall back to server defaults
                 if ($recipient->EmailFrom) {
-                    $email->setFrom(explode(',', $recipient->EmailFrom ?? ''));
+                    $email->setFrom($this->validEmailsToArray($recipient->EmailFrom));
                 }
 
                 // check to see if they are a dynamic reciever eg based on a dropdown field a user selected
@@ -452,12 +454,12 @@ JS
                         $submittedFormField = $submittedFields->find('Name', $recipient->SendEmailToField()->Name);
 
                         if ($submittedFormField && is_string($submittedFormField->Value)) {
-                            $email->setTo(explode(',', $submittedFormField->Value ?? ''));
+                            $email->setTo($this->validEmailsToArray($submittedFormField->Value));
                         } else {
-                            $email->setTo(explode(',', $recipient->EmailAddress ?? ''));
+                            $email->setTo($this->validEmailsToArray($recipient->EmailAddress));
                         }
                     } else {
-                        $email->setTo(explode(',', $recipient->EmailAddress ?? ''));
+                        $email->setTo($this->validEmailsToArray($recipient->EmailAddress));
                     }
                 } catch (Swift_RfcComplianceException $e) {
                     // The sending address is empty and/or invalid. Log and skip sending.
@@ -671,5 +673,22 @@ EOS;
         }
 
         return $result;
+    }
+
+    /**
+     * Check validity of email and return array of valid emails
+     */
+    private function validEmailsToArray(?string $emails): array
+    {
+        $emailsArray = [];
+        $emails = explode(',', $emails ?? '');
+        foreach ($emails as $email) {
+            $email = trim($email);
+            if (Email::is_valid_address($email)) {
+                $emailsArray[] = $email;
+            }
+        }
+
+        return $emailsArray;
     }
 }

--- a/tests/php/Control/UserDefinedFormControllerTest.php
+++ b/tests/php/Control/UserDefinedFormControllerTest.php
@@ -2,6 +2,7 @@
 
 namespace SilverStripe\UserForms\Tests\Control;
 
+use ReflectionClass;
 use SilverStripe\Assets\Dev\TestAssetStore;
 use SilverStripe\Assets\File;
 use SilverStripe\Assets\Folder;
@@ -579,5 +580,37 @@ class UserDefinedFormControllerTest extends FunctionalTest
         $this->expectException('\InvalidArgumentException');
         $controller = new SizeStringTestableController(); // extends UserDefinedFormController
         $controller->convertSizeStringToBytes($input);
+    }
+
+    public function provideValidEmailsToArray()
+    {
+        return [
+            [[], [null]],
+            [[], [' , , ']],
+            [[], ['broken.email, broken@.email, broken2.@email']],
+            [
+                ['broken@email', 'correctemail@email.com'],
+                [', broken@email, email@-email.com,correctemail@email.com,']
+            ],
+            [
+                ['correctemail1@email.com', 'correctemail2@email.com', 'correctemail3@email.com'],
+                ['correctemail1@email.com, correctemail2@email.com, correctemail3@email.com']
+            ]
+        ];
+    }
+
+    /**
+     * @dataProvider provideValidEmailsToArray
+     * Test that provided email is valid
+     */
+    public function testValidEmailsToArray(array $expectedOutput, array $input)
+    {
+        $class = new ReflectionClass(UserDefinedFormController::class);
+        $method = $class->getMethod('validEmailsToArray');
+        $method->setAccessible(true);
+
+        $controller = new UserDefinedFormController();
+
+        $this->assertEquals($expectedOutput, $method->invokeArgs($controller, $input));
     }
 }


### PR DESCRIPTION
### Description
- `SilverStripe\Control\Email\Email::setReplyTo(string $address, string $name = '')` gets string as a first argument, but `UserDefinedFormController::process` invokes this method and passes an array of emails.

- Additional validation of the email address has been added.

### Parent issue
- https://github.com/silverstripe/silverstripe-userforms/issues/1207
