### PR TITLE
FIX Use absolute URL for submitted file links in emails

### DIFF
--- a/code/Model/Submission/SubmittedFileField.php
+++ b/code/Model/Submission/SubmittedFileField.php
@@ -3,6 +3,7 @@
 namespace SilverStripe\UserForms\Model\Submission;
 
 use SilverStripe\Assets\File;
+use SilverStripe\Control\Director;
 use SilverStripe\ORM\FieldType\DBField;
 use SilverStripe\Versioned\Versioned;
 
@@ -83,7 +84,11 @@ class SubmittedFileField extends SubmittedFormField
     {
         if ($file = $this->getUploadedFileFromDraft()) {
             if ($file->exists()) {
-                return $file->getURL($grant);
+                $url = $file->getURL($grant);
+                if ($url) {
+                    return Director::absoluteURL($url);
+                }
+                return null;
             }
         }
     }

--- a/tests/php/Model/SubmittedFileFieldTest.php
+++ b/tests/php/Model/SubmittedFileFieldTest.php
@@ -5,6 +5,7 @@ namespace SilverStripe\UserForms\Tests\Model;
 use SilverStripe\Assets\Dev\TestAssetStore;
 use SilverStripe\Assets\File;
 use SilverStripe\Assets\Storage\AssetStore;
+use SilverStripe\Control\Director;
 use SilverStripe\Core\Injector\Injector;
 use SilverStripe\Dev\SapphireTest;
 use SilverStripe\UserForms\Model\Submission\SubmittedFileField;
@@ -69,21 +70,23 @@ class SubmittedFileFieldTest extends SapphireTest
 
     public function testGetFormattedValue()
     {
+        // Set an explicit base URL so we get a reliable value for the test
+        Director::config()->set('alternate_base_url', 'http://mysite.com');
         $fileName = $this->submittedFile->getFileName();
         $message = "You don&#039;t have the right permissions to download this file";
 
         $this->file->CanViewType = 'OnlyTheseUsers';
         $this->file->write();
-        
+
         $this->loginWithPermission('ADMIN');
         $this->assertEquals(
             sprintf(
-                '%s - <a href="/assets/3c01bdbb26/test-SubmittedFileFieldTest.txt" target="_blank">Download File</a>',
+                '%s - <a href="http://mysite.com/assets/3c01bdbb26/test-SubmittedFileFieldTest.txt" target="_blank">Download File</a>',
                 $fileName
             ),
             $this->submittedFile->getFormattedValue()->value
         );
-            
+
         $this->loginWithPermission('CMS_ACCESS_CMSMain');
         $this->assertEquals(
             sprintf(


### PR DESCRIPTION
Mimic `$file->getAbsoluteURL()` while still respecting file grant rules.

## Issue
- https://github.com/silverstripe/silverstripe-userforms/issues/1217