### PR TITLE
MNT Fix behat test

### DIFF
--- a/tests/behat/features/userforms.feature
+++ b/tests/behat/features/userforms.feature
@@ -35,6 +35,7 @@ Feature: Userforms
     And I fill in "Options[GridFieldAddNewInlineButton][2][Value]" with "2"
     And I press the "Save" button
     And I follow "My userform"
+    And I click the "Form Fields" CMS tab
 
     # Create textfields
     And I press the "Add Field" button
@@ -59,15 +60,17 @@ Feature: Userforms
     And I wait for 5 seconds
 
     # Edit My textfield 3
-    When I click on the ".ss-gridfield-item[data-id='6'] .edit-link" element
+    When I click the "Form Fields" CMS tab
+    And I click on the ".ss-gridfield-item[data-id='6'] .edit-link" element
     And I click the "Validation" CMS tab
     And I check "Is this field Required?"
     And I press the "Save" button
     And I follow "My userform"
+    And I click the "Form Fields" CMS tab
 
     # Drag and drop my text field 2 to Page Two
     Then I drag the ".ss-gridfield-item[data-id='4'] .handle" element to the ".ss-gridfield-item[data-id='6'] .handle" element
-    And I wait for 1 seconds
+    And I wait for 2 seconds
     And I press the "Publish" button
     And I dismiss all toasts
 


### PR DESCRIPTION
Fixes https://github.com/silverstripe/silverstripe-userforms/actions/runs/8134148824/job/22226690887#step:12:208

Seems that previously when you clicked on an item in the sitetree i.e. `And I follow "My userform"` that it would remember the tab you were previously on.  That doesn't seem to happen anymore so need to update the behat test to click on the form fields tab i.e. `And I click the "Form Fields" CMS tab` 
