### PR TITLE
Added extension hook for modifying submission export columns

### DIFF
--- a/code/UserForm.php
+++ b/code/UserForm.php
@@ -325,6 +325,8 @@ SQL;
         // attach every column to the print view form
         $columns['Created'] = 'Created';
         $columns['SubmittedBy.Email'] = 'Submitter';
+        $this->extend('updateSubmissionsGridFieldExportColumns', $columns);
+
         $filter->setColumns($columns);
 
         // print configuration

--- a/code/UserForm.php
+++ b/code/UserForm.php
@@ -325,8 +325,6 @@ SQL;
         // attach every column to the print view form
         $columns['Created'] = 'Created';
         $columns['SubmittedBy.Email'] = 'Submitter';
-        $this->extend('updateSubmissionsGridFieldExportColumns', $columns);
-
         $filter->setColumns($columns);
 
         // print configuration
@@ -343,6 +341,9 @@ SQL;
             $this->Submissions()->sort('Created', 'DESC'),
             $config
         );
+
+        $this->extend('updateSubmissionsGridField', $submissions);
+
         return $submissions;
     }
 


### PR DESCRIPTION
## Description
Adds an extension hook in `UserForm` `getSubmissionsGridField` to make it possible to modify the `$columns` that appear in the exported (or printed) CSV. 

## Issues
- #1272

## Pull request checklist
<!--
  PLEASE check each of these to ensure you have done everything you need to do!
  If there's something in this list you need help with, please ask so that we can assist you.
-->
- [x] The target branch is correct
    - See [picking the right version](https://docs.silverstripe.org/en/contributing/code/#picking-the-right-version)
- [x] All commits are relevant to the purpose of the PR (e.g. no debug statements, unrelated refactoring, or arbitrary linting)
    - Small amounts of additional linting are usually okay, but if it makes it hard to concentrate on the relevant changes, ask for the unrelated changes to be reverted, and submitted as a separate PR.
- [ ] The commit messages follow our [commit message guidelines](https://docs.silverstripe.org/en/contributing/code/#commit-messages)
- [x] The PR follows our [contribution guidelines](https://docs.silverstripe.org/en/contributing/code/)
- [x] Code changes follow our [coding conventions](https://docs.silverstripe.org/en/contributing/coding_conventions/)
- [x] This change is covered with tests (or tests aren't necessary for this change)
- [x] Any relevant User Help/Developer documentation is updated; for impactful changes, information is added to the changelog for the intended release
- [x] CI is green
