### PR TITLE
ENH - Add 'Includes' condition option to EmailRecipientCondition

### DIFF
--- a/code/Model/Recipient/EmailRecipientCondition.php
+++ b/code/Model/Recipient/EmailRecipientCondition.php
@@ -37,11 +37,12 @@ class EmailRecipientCondition extends DataObject
         'ValueLessThan' => 'Less than',
         'ValueLessThanEqual' => 'Less than or equal',
         'ValueGreaterThan' => 'Greater than',
-        'ValueGreaterThanEqual' => 'Greater than or equal'
+        'ValueGreaterThanEqual' => 'Greater than or equal',
+        'Includes' => 'Includes'
     ];
 
     private static $db = [
-        'ConditionOption' => 'Enum("IsBlank,IsNotBlank,Equals,NotEquals,ValueLessThan,ValueLessThanEqual,ValueGreaterThan,ValueGreaterThanEqual")',
+        'ConditionOption' => 'Enum("IsBlank,IsNotBlank,Equals,NotEquals,ValueLessThan,ValueLessThanEqual,ValueGreaterThan,ValueGreaterThanEqual,Includes")',
         'ConditionValue' => 'Varchar'
     ];
 
@@ -95,6 +96,11 @@ class EmailRecipientCondition extends DataObject
                 if ($this->ConditionOption == 'NotEquals') {
                     $result = !($result);
                 }
+                break;
+            case 'Includes':
+                $result = is_array($fieldValue)
+                    ? in_array($conditionValue, $fieldValue)
+                    : stripos($fieldValue, $conditionValue) !== false;
                 break;
             default:
                 throw new LogicException("Unhandled rule {$this->ConditionOption}");

--- a/code/Model/Recipient/EmailRecipientCondition.php
+++ b/code/Model/Recipient/EmailRecipientCondition.php
@@ -100,7 +100,7 @@ class EmailRecipientCondition extends DataObject
             case 'Includes':
                 $result = is_array($fieldValue)
                     ? in_array($conditionValue, $fieldValue)
-                    : stripos($fieldValue, $conditionValue) !== false;
+                    : stripos($fieldValue ?? '', $conditionValue) !== false;
                 break;
             default:
                 throw new LogicException("Unhandled rule {$this->ConditionOption}");


### PR DESCRIPTION
<!--
  Thanks for contributing, you're awesome! ⭐

  Please read https://docs.silverstripe.org/en/contributing/code/ if you haven't contributed to this project recently.
-->
## Description
<!--
  Please describe expected and observed behaviour, and what you're fixing.
  For visual fixes, please include tested browsers and screenshots.
-->



## Manual testing steps
<!--
  Include any manual testing steps here which a reviewer can perform to validate your pull request works correctly.
  Note that this DOES NOT replace unit or end-to-end tests.
-->

## Issues
<!--
  List all issues here that this pull request fixes/resolves.
  If there is no issue already, create a new one! You must link your pull request to at least one issue.
-->
- https://github.com/silverstripe/silverstripe-userforms/issues/1274

## Pull request checklist
<!--
  PLEASE check each of these to ensure you have done everything you need to do!
  If there's something in this list you need help with, please ask so that we can assist you.
-->
- [x] The target branch is correct
    - See [picking the right version](https://docs.silverstripe.org/en/contributing/code/#picking-the-right-version)
- [x] All commits are relevant to the purpose of the PR (e.g. no debug statements, unrelated refactoring, or arbitrary linting)
    - Small amounts of additional linting are usually okay, but if it makes it hard to concentrate on the relevant changes, ask for the unrelated changes to be reverted, and submitted as a separate PR.
- [x] The commit messages follow our [commit message guidelines](https://docs.silverstripe.org/en/contributing/code/#commit-messages)
- [x] The PR follows our [contribution guidelines](https://docs.silverstripe.org/en/contributing/code/)
- [x] Code changes follow our [coding conventions](https://docs.silverstripe.org/en/contributing/coding_conventions/)
- [x] This change is covered with tests (or tests aren't necessary for this change)
- [x] Any relevant User Help/Developer documentation is updated; for impactful changes, information is added to the changelog for the intended release
- [x] CI is green
