### PR TITLE
FIX Don't emit deprecation warning for calling deprecated methods

### DIFF
--- a/code/UserForm.php
+++ b/code/UserForm.php
@@ -37,6 +37,7 @@ use SilverStripe\UserForms\Model\Submission\SubmittedForm;
 use SilverStripe\UserForms\Model\EditableFormField;
 use SilverStripe\View\Requirements;
 use SilverStripe\Core\Config\Configurable;
+use SilverStripe\Dev\Deprecation;
 
 /**
  * Defines the user defined functionality to be applied to any {@link DataObject}
@@ -318,9 +319,11 @@ SQL;
             $config->addComponent(new BulkManager);
         }
 
-        $sort->setThrowExceptionOnBadDataType(false);
-        $filter->setThrowExceptionOnBadDataType(false);
-        $pagination->setThrowExceptionOnBadDataType(false);
+        Deprecation::withNoReplacement(function () use ($sort, $filter, $pagination) {
+            $sort->setThrowExceptionOnBadDataType(false);
+            $filter->setThrowExceptionOnBadDataType(false);
+            $pagination->setThrowExceptionOnBadDataType(false);
+        });
 
         // attach every column to the print view form
         $columns['Created'] = 'Created';


### PR DESCRIPTION
`UserForm` is calling the deprecated method `setThrowExceptionOnBadDataType()`. That can't be avoided without breaking changes, so we need to wraps those calls in `Deprecation::withNoReplacement()` so the deprecation warning isn't logged unless developers _really_ want it.

## Issue
- https://github.com/silverstripe/silverstripe-userforms/issues/1292