### PR TITLE
fix: prevent CMS requirements from leaking into preview email

### DIFF
--- a/code/Model/Recipient/UserFormRecipientItemRequest.php
+++ b/code/Model/Recipient/UserFormRecipientItemRequest.php
@@ -9,6 +9,7 @@ use SilverStripe\ORM\FieldType\DBField;
 use SilverStripe\UserForms\Model\EditableFormField\EditableFormHeading;
 use SilverStripe\UserForms\Model\EditableFormField\EditableLiteralField;
 use SilverStripe\View\ArrayData;
+use SilverStripe\View\Requirements;
 use SilverStripe\View\SSViewer;
 
 /**
@@ -34,13 +35,17 @@ class UserFormRecipientItemRequest extends GridFieldDetailForm_ItemRequest
         Config::nest();
         Config::modify()->set(SSViewer::class, 'theme_enabled', true);
 
+        Requirements::clear();
+
         $content = $this->customise([
             'Body' => $this->record->getEmailBodyContent(),
             'HideFormData' => (bool) $this->record->HideFormData,
             'Fields' => $this->getPreviewFieldData()
         ])->renderWith($this->record->EmailTemplate);
 
+        Requirements::restore();
         Config::unnest();
+
 
         return $content;
     }


### PR DESCRIPTION
## Description

When previewing an email template, the current behaviour is to include existing CMS styles which can be misleading.

## Manual testing steps

* Create a HTML template for the email recipient 
* Notice that the HTML template includes CSS when previewing.

## Issues
<!--
  List all issues here that this pull request fixes/resolves.
  If there is no issue already, create a new one! You must link your pull request to at least one issue.
-->
- https://github.com/silverstripe/silverstripe-userforms/issues/1300

## Pull request checklist

- [x] The target branch is correct
    - See [picking the right version](https://docs.silverstripe.org/en/contributing/code/#picking-the-right-version)
- [x] All commits are relevant to the purpose of the PR (e.g. no debug statements, unrelated refactoring, or arbitrary linting)
    - Small amounts of additional linting are usually okay, but if it makes it hard to concentrate on the relevant changes, ask for the unrelated changes to be reverted, and submitted as a separate PR.
- [x] The commit messages follow our [commit message guidelines](https://docs.silverstripe.org/en/contributing/code/#commit-messages)
- [x] The PR follows our [contribution guidelines](https://docs.silverstripe.org/en/contributing/code/)
- [x] Code changes follow our [coding conventions](https://docs.silverstripe.org/en/contributing/coding_conventions/)
- [x] This change is covered with tests (or tests aren't necessary for this change)
- [x] Any relevant User Help/Developer documentation is updated; for impactful changes, information is added to the changelog for the intended release
- [x] CI is green

![Screenshot 2024-05-31 at 10 23 29 AM](https://github.com/silverstripe/silverstripe-userforms/assets/101629/3934d1b4-1d0c-40d4-8010-c115805a674a)

