### PR TITLE
DEP Bump minimum version of framework

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -31,7 +31,7 @@
     ],
     "require": {
         "php": "^7.4 || ^8.0",
-        "silverstripe/framework": "^4.10",
+        "silverstripe/framework": "^4.13",
         "silverstripe/cms": "^4.6",
         "symbiote/silverstripe-gridfieldextensions": "^3.1",
         "silverstripe/segment-field": "^2.2",


### PR DESCRIPTION
Issue https://github.com/silverstripe/.github/issues/284

Failing on Deprecation::isEnabled() on --prefer-lowest build

https://github.com/silverstripe/silverstripe-userforms/actions/runs