### PR TITLE
FIX Update EditableFormHeading.php to output unique ID attributes to comply with accessibility standards

### DIFF
--- a/code/Model/EditableFormField/EditableFormHeading.php
+++ b/code/Model/EditableFormField/EditableFormHeading.php
@@ -70,7 +70,7 @@ class EditableFormHeading extends EditableFormField
 
     public function getFormField()
     {
-        $labelField = HeaderField::create('userforms-header', $this->Title ?: false)
+        $labelField = HeaderField::create('userforms-header-' . $this->ID, $this->Title ?: false)
             ->setHeadingLevel($this->Level);
         $labelField->addExtraClass('FormHeading');
         $labelField->setAttribute('data-id', $this->Name);


### PR DESCRIPTION
Fixes:

Multiple HeaderFields in UserForm creates WCAG Duplicate ID issue #1290

https://github.com/silverstripe/silverstripe-userforms/issues/1290

## Description
As a CMS author I want to be able add multiple EditableFormHeading fields to my user and I want all EditableFormHeading ID attributes to be unique so that my UserForm contains valid html.

## Manual testing steps
- Create a CMS UserForm. 
- Add multiple heading fields to the form.
- Check that all frontend rendered Heading fields have unique ID attributes.
https://validator.w3.org/
- check that there is also no impact on the defult bundled JS solutions (that hide/show fields, etc.)
  
## Issues
- https://github.com/silverstripe/silverstripe-userforms/issues/1290

## Pull request checklist
- [x] The target branch is correct
    - See [picking the right version](https://docs.silverstripe.org/en/contributing/code/#picking-the-right-version)
- [x] All commits are relevant to the purpose of the PR (e.g. no debug statements, unrelated refactoring, or arbitrary linting)
    - Small amounts of additional linting are usually okay, but if it makes it hard to concentrate on the relevant changes, ask for the unrelated changes to be reverted, and submitted as a separate PR.
- [x] The commit messages follow our [commit message guidelines](https://docs.silverstripe.org/en/contributing/code/#commit-messages)
- [x] The PR follows our [contribution guidelines](https://docs.silverstripe.org/en/contributing/code/)
- [x] Code changes follow our [coding conventions](https://docs.silverstripe.org/en/contributing/coding_conventions/)
- [x] This change is covered with tests (or tests aren't necessary for this change)
- [x] Any relevant User Help/Developer documentation is updated; for impactful changes, information is added to the changelog for the intended release
- [x] CI is green
