### PR TITLE
MNT Ignore phpstan error we can't fix

### DIFF
--- a/code/Model/Recipient/EmailRecipient.php
+++ b/code/Model/Recipient/EmailRecipient.php
@@ -575,6 +575,7 @@ class EmailRecipient extends DataObject
                 foreach ($addresses as $address) {
                     $trimAddress = trim($address ?? '');
                     if ($trimAddress && !Email::is_valid_address($trimAddress)) {
+                        /** @phpstan-ignore translation.key (can't simplify the key without lots of duplicated code) */
                         $error = _t(
                             __CLASS__.".$translation",
                             "Invalid email address $trimAddress"


### PR DESCRIPTION
Fixes https://github.com/silverstripe/silverstripe-userforms/actions/runs/10330361902/job/28599299481
> Can't determine value of first argument to _t(). Use a simpler value.

## Issue
- https://github.com/silverstripe/.github/issues/290