### PR TITLE
ENH: Injectable GridField config components.

### DIFF
--- a/code/Extension/UserFormFieldEditorExtension.php
+++ b/code/Extension/UserFormFieldEditorExtension.php
@@ -60,7 +60,7 @@ class UserFormFieldEditorExtension extends DataExtension
     {
         $fieldEditor = $this->getFieldEditorGrid();
 
-        $fields->insertAfter('Main', new Tab('FormFields', _t(__CLASS__.'.FORMFIELDS', 'Form Fields')));
+        $fields->insertAfter('Main', Tab::create('FormFields', _t(__CLASS__.'.FORMFIELDS', 'Form Fields')));
         $fields->addFieldToTab('Root.FormFields', $fieldEditor);
 
         return $fields;
@@ -81,7 +81,7 @@ class UserFormFieldEditorExtension extends DataExtension
 
         $this->createInitialFormStep(true);
 
-        $editableColumns = new GridFieldEditableColumns();
+        $editableColumns = GridFieldEditableColumns::create();
         $fieldClasses = singleton(EditableFormField::class)->getEditableFieldClasses();
         $editableColumns->setDisplayFields([
             'ClassName' => function ($record, $column, $grid) use ($fieldClasses) {
@@ -103,7 +103,7 @@ class UserFormFieldEditorExtension extends DataExtension
         $config = GridFieldConfig::create()
             ->addComponents(
                 $editableColumns,
-                new GridFieldButtonRow(),
+                GridFieldButtonRow::create(),
                 (new GridFieldAddClassesButton(EditableTextField::class))
                     ->setButtonName(_t(__CLASS__.'.ADD_FIELD', 'Add Field'))
                     ->setButtonClass('btn-primary'),
@@ -113,13 +113,13 @@ class UserFormFieldEditorExtension extends DataExtension
                 (new GridFieldAddClassesButton([EditableFieldGroup::class, EditableFieldGroupEnd::class]))
                     ->setButtonName(_t(__CLASS__.'.ADD_FIELD_GROUP', 'Add Field Group'))
                     ->setButtonClass('btn-secondary'),
-                $editButton = new GridFieldEditButton(),
-                new GridFieldDeleteAction(),
-                new GridFieldToolbarHeader(),
-                new GridFieldOrderableRows('Sort'),
-                new GridFieldDetailForm(),
+                $editButton = GridFieldEditButton::create(),
+                GridFieldDeleteAction::create(),
+                GridFieldToolbarHeader::create(),
+                GridFieldOrderableRows::create('Sort'),
+                GridFieldDetailForm::create(),
                 // Betterbuttons prev and next is enabled by adding a GridFieldPaginator component
-                new GridFieldPaginator(999)
+                GridFieldPaginator::create(999)
             );
 
         $editButton->removeExtraClass('grid-field__icon-action--hidden-on-hover');


### PR DESCRIPTION
# ENH: Injectable GridField config components.

## Description

Allow GridField config components to be injectable so we have more configuration options.

## Issues

* https://github.com/silverstripe/silverstripe-userforms/issues/1327

## Note

Failing tests are an upstream error, not related to this changeset.

## Pull request checklist
- [x] The target branch is correct
    - See [picking the right version](https://docs.silverstripe.org/en/contributing/code/#picking-the-right-version)
- [x] All commits are relevant to the purpose of the PR (e.g. no debug statements, unrelated refactoring, or arbitrary linting)
    - Small amounts of additional linting are usually okay, but if it makes it hard to concentrate on the relevant changes, ask for the unrelated changes to be reverted, and submitted as a separate PR.
- [ ] The commit messages follow our [commit message guidelines](https://docs.silverstripe.org/en/contributing/code/#commit-messages)
- [x] The PR follows our [contribution guidelines](https://docs.silverstripe.org/en/contributing/code/)
- [x] Code changes follow our [coding conventions](https://docs.silverstripe.org/en/contributing/coding_conventions/)
- [x] This change is covered with tests (or tests aren't necessary for this change)
- [x] Any relevant User Help/Developer documentation is updated; for impactful changes, information is added to the changelog for the intended release
- [x] CI is green
