### PR TITLE
DEP Bump framework dependency 'cause we're using new API

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -31,7 +31,7 @@
     ],
     "require": {
         "php": "^8.1",
-        "silverstripe/framework": "^5",
+        "silverstripe/framework": "^5.4",
         "silverstripe/cms": "^5",
         "symbiote/silverstripe-gridfieldextensions": "^4",
         "silverstripe/segment-field": "^3",


### PR DESCRIPTION
Fixes https://github.com/silverstripe/silverstripe-userforms/actions/runs/11005530565/job/30558348748

> Call to undefined method SilverStripe\Dev\Deprecation::withSuppressedNotice()

## Issue
- https://github.com/silverstripe/.github/issues/313