### PR TITLE
ENH Use config instead of runtime code to remove menu item

### DIFF
--- a/_config.php
+++ b/_config.php
@@ -1,6 +1,0 @@
-<?php
-
-use SilverStripe\Admin\CMSMenu;
-use SilverStripe\UserForms\Control\UserDefinedFormAdmin;
-
-CMSMenu::remove_menu_class(UserDefinedFormAdmin::class);

--- a/code/Control/UserDefinedFormAdmin.php
+++ b/code/Control/UserDefinedFormAdmin.php
@@ -47,6 +47,8 @@ class UserDefinedFormAdmin extends LeftAndMain
 
     private static $url_segment = 'user-forms';
 
+    private static $ignore_menuitem = true;
+
     /**
      * @var string The name of the folder where form submissions will be placed by default
      */


### PR DESCRIPTION
Quick tidyup to use the `ignore_menuitem` configuration property instead of removing the menu item at runtime.

Can't refactor to use `AdminController` instead of `LeftAndMain` yet because it needs formschema - but this small refactor will make that slightly easier when I come to it.

## Issue
- https://github.com/silverstripe/silverstripe-admin/issues/1761