### PR TITLE
FIX Allow setMaxLength for all field types (TextField, TextareaField)

### DIFF
--- a/code/Model/EditableFormField/EditableTextField.php
+++ b/code/Model/EditableFormField/EditableTextField.php
@@ -2,6 +2,7 @@
 
 namespace SilverStripe\UserForms\Model\EditableFormField;
 
+use SilverStripe\Core\ClassInfo;
 use SilverStripe\Forms\DropdownField;
 use SilverStripe\Forms\FieldGroup;
 use SilverStripe\Forms\FieldList;
@@ -185,7 +186,7 @@ class EditableTextField extends EditableFormField
         }
 
         if (is_numeric($this->MaxLength) && $this->MaxLength > 0) {
-            if ($field instanceof TextField) {
+            if (ClassInfo::hasMethod($field, 'setMaxLength')) {
                 $field->setMaxLength((int) $this->MaxLength);
             }
             $field->setAttribute('data-rule-maxlength', (int) $this->MaxLength);

--- a/tests/php/Model/EditableFormFieldTest.php
+++ b/tests/php/Model/EditableFormFieldTest.php
@@ -232,7 +232,7 @@ class EditableFormFieldTest extends FunctionalTest
         // textarea
         $textField->Rows = 3;
         $attributes = $textField->getFormField()->getAttributes();
-        $this->assertFalse(isset($attributes['maxLength']));
+        $this->assertEquals(20, $attributes['maxlength']);
         $this->assertEquals(10, $attributes['data-rule-minlength']);
         $this->assertEquals(20, $attributes['data-rule-maxlength']);
     }


### PR DESCRIPTION
## Issues
<!--
  List all issues here that this pull request fixes/resolves.
  If there is no issue already, create a new one! You must link your pull request to at least one issue.
-->
- https://github.com/silverstripe/silverstripe-userforms/issues/1232

## Pull request checklist
<!--
  PLEASE check each of these to ensure you have done everything you need to do!
  If there's something in this list you need help with, please ask so that we can assist you.
-->
- [x] The target branch is correct
    - See [picking the right version](https://docs.silverstripe.org/en/contributing/code/#picking-the-right-version)
- [x] All commits are relevant to the purpose of the PR (e.g. no debug statements, unrelated refactoring, or arbitrary linting)
    - Small amounts of additional linting are usually okay, but if it makes it hard to concentrate on the relevant changes, ask for the unrelated changes to be reverted, and submitted as a separate PR.
- [x] The commit messages follow our [commit message guidelines](https://docs.silverstripe.org/en/contributing/code/#commit-messages)
- [x] The PR follows our [contribution guidelines](https://docs.silverstripe.org/en/contributing/code/)
- [x] Code changes follow our [coding conventions](https://docs.silverstripe.org/en/contributing/coding_conventions/)
- [x] This change is covered with tests (or tests aren't necessary for this change)
- [ ] Any relevant User Help/Developer documentation is updated; for impactful changes, information is added to the changelog for the intended release
- [x] CI is green
