### PR TITLE
API Stop using deprecated LeftAndMain::SCHEMA_HEADER const

### DIFF
--- a/code/Control/UserDefinedFormAdmin.php
+++ b/code/Control/UserDefinedFormAdmin.php
@@ -139,7 +139,7 @@ class UserDefinedFormAdmin extends LeftAndMain
         }
 
         // create the schema response
-        $parts = $this->getRequest()->getHeader(static::SCHEMA_HEADER);
+        $parts = $this->getRequest()->getHeader(FormSchema::SCHEMA_HEADER);
         $schemaID = $this->getRequest()->getURL();
         $data = FormSchema::singleton()->getMultipartSchema($parts, $schemaID, $form);
 


### PR DESCRIPTION
## Issue
- https://github.com/silverstripe/silverstripe-cms/issues/2949