### PR TITLE
ENH Add custom confirmation page

### DIFF
--- a/code/Control/UserDefinedFormController.php
+++ b/code/Control/UserDefinedFormController.php
@@ -556,6 +556,14 @@ JS
             $session->set('userformssubmission'. $this->ID, $submittedForm->ID);
         }
 
+        // If set, redirect to custom thank you page
+        if ($this->data()->ConfirmationPageID) {
+            $confirmationPage = $this->data()->ConfirmationPage();
+            if ($confirmationPage && $confirmationPage->exists()) {
+                return $this->redirect($confirmationPage->Link() . $referrer);
+            }
+        }
+
         return $this->redirect($this->Link('finished') . $referrer . $this->config()->get('finished_anchor'));
     }
 

--- a/code/UserForm.php
+++ b/code/UserForm.php
@@ -34,6 +34,8 @@ use SilverStripe\UserForms\Model\Submission\SubmittedForm;
 use SilverStripe\UserForms\Model\EditableFormField;
 use SilverStripe\View\Requirements;
 use SilverStripe\Core\Config\Configurable;
+use SilverStripe\CMS\Model\SiteTree;
+use SilverStripe\Forms\TreeDropdownField;
 
 /**
  * Defines the user defined functionality to be applied to any {@link DataObject}
@@ -115,6 +117,13 @@ trait UserForm
     private static $has_many = [
         'EmailRecipients' => EmailRecipient::class,
         'Submissions' => SubmittedForm::class,
+    ];
+
+    /**
+     * @var array
+     */
+    private static $has_one = [
+        'ConfirmationPage' => SiteTree::class,
     ];
 
     private static $cascade_deletes = [
@@ -210,7 +219,12 @@ trait UserForm
                 CheckboxField::create(
                     'DisableSaveSubmissions',
                     _t('SilverStripe\\UserForms\\Model\\UserDefinedForm.SAVESUBMISSIONS', 'Disable Saving Submissions to Server')
-                )
+                ),
+                TreeDropdownField::create(
+                    'ConfirmationPageID',
+                    _t('SilverStripe\\UserForms\\Model\\UserDefinedForm.CONFIRMATIONPAGE', 'Custom confirmation page'),
+                    SiteTree::class
+                ),
             ]);
             $editor->setRows(3);
             $label->addExtraClass('left');

--- a/lang/ar.yml
+++ b/lang/ar.yml
@@ -139,6 +139,7 @@ ar:
     ADDEMAILRECIPIENT: 'أضف متلقي البريد الإلكتروني'
     CLASS_DESCRIPTION: 'يضيف استمارة مخصصة.'
     CONFIGURATION: المواصفات
+    CONFIRMATIONPAGE: 'صفحة التأكيد المخصصة'
     DESCRIPTION: 'يضيف استمارة مخصصة.'
     EMAILADDRESS: 'البريد الإلكتروني'
     EMAILBODY: هيئة

--- a/lang/bg_BG.yml
+++ b/lang/bg_BG.yml
@@ -13,6 +13,7 @@ bg_BG:
     db_EmailSubject: 'Email Subject'
     has_one_Form: Формуляр
   SilverStripe\UserForms\Model\UserDefinedForm:
+    CONFIRMATIONPAGE: 'Потребителска страница за потвърждение'
     EMAILSUBJECT: 'Email Subject'
     FROMADDRESS: 'Send Email From'
     HIDEFORMDATA: 'Hide Form Data from Email'

--- a/lang/da_DK.yml
+++ b/lang/da_DK.yml
@@ -13,6 +13,7 @@ da_DK:
     db_EmailSubject: 'Email Subject'
     has_one_Form: Formular
   SilverStripe\UserForms\Model\UserDefinedForm:
+    CONFIRMATIONPAGE: 'Brugerdefineret bekræftelsesside'
     EMAILSUBJECT: 'Email Subject'
     FROMADDRESS: 'Send Email From'
     HIDEFORMDATA: 'Hide Form Data from Email'

--- a/lang/de.yml
+++ b/lang/de.yml
@@ -81,6 +81,7 @@ de:
     ADDEMAILRECIPIENT: 'E-Mail-Empfänger hinzufügen'
     CLEARBUTTON: Löschen
     CONFIGURATION: Einstellungen
+    CONFIRMATIONPAGE: 'Benutzerdefinierte Bestätigungsseite'
     DISABLECSRFSECURITYTOKEN: 'Deaktiviere CSRF-Token'
     DISPLAYERRORMESSAGESATTOP: 'Fehlermeldungen über dem Formular anzeigen?'
     EMAILADDRESS: E-Mail

--- a/lang/de_DE.yml
+++ b/lang/de_DE.yml
@@ -178,6 +178,7 @@ de_DE:
     CLASS_DESCRIPTION: 'Fügt ein anpassbares Formular hinzu.'
     CLEARBUTTON: Löschen
     CONFIGURATION: Konfiguration
+    CONFIRMATIONPAGE: 'Benutzerdefinierte Bestätigungsseite'
     DESCRIPTION: 'Fügt ein anpassbares Formular hinzu.'
     DISABLECSRFSECURITYTOKEN: 'Deaktiviere CSRF-Token'
     DISPLAYERRORMESSAGESATTOP: 'Fehlermeldungen über dem Formular anzeigen?'

--- a/lang/en.yml
+++ b/lang/en.yml
@@ -356,6 +356,7 @@ en:
     CLASS_DESCRIPTION: 'Adds a customizable form.'
     CLEARBUTTON: Clear
     CONFIGURATION: Configuration
+    CONFIRMATIONPAGE: 'Custom confirmation page'
     DESCRIPTION: 'Adds a customizable form.'
     DISABLEAUTHENICATEDFINISHACTION: 'Disable Authentication on finish action'
     DISABLECSRFSECURITYTOKEN: 'Disable CSRF Token'

--- a/lang/eo.yml
+++ b/lang/eo.yml
@@ -354,6 +354,7 @@ eo:
     CLASS_DESCRIPTION: 'Aldonas adapteblan formularon'
     CLEARBUTTON: Vakigi
     CONFIGURATION: Agordaro
+    CONFIRMATIONPAGE: 'Propra konfirma paĝo'
     DESCRIPTION: 'Aldonas adapteblan formularon'
     DISABLEAUTHENICATEDFINISHACTION: 'Malŝalti aŭtentigon de kompletiga ago'
     DISABLECSRFSECURITYTOKEN: 'Malŝalti CSRF-ĵetonon'

--- a/lang/es.yml
+++ b/lang/es.yml
@@ -60,6 +60,7 @@ es:
     has_one_Parent: Padre
   SilverStripe\UserForms\Model\UserDefinedForm:
     CLEARBUTTON: Limpiar
+    CONFIRMATIONPAGE: 'Página de confirmación personalizada'
     EMAILADDRESS: 'Correo electrónico'
     EMAILFROM: De
     EMAILSUBJECT: 'Asunto del Email'

--- a/lang/es_ES.yml
+++ b/lang/es_ES.yml
@@ -134,6 +134,7 @@ es_ES:
     ADDEMAILRECIPIENT: 'Agregar destinatario de email'
     CLASS_DESCRIPTION: 'Agrega un formulario personalizable.'
     CONFIGURATION: Configuración
+    CONFIRMATIONPAGE: 'Página de confirmación personalizada'
     DESCRIPTION: 'Agrega un formulario personalizable.'
     EMAILBODY: Cuerpo
     EMAILBODYHTML: Cuerpo

--- a/lang/fa_IR.yml
+++ b/lang/fa_IR.yml
@@ -96,6 +96,7 @@ fa_IR:
   SilverStripe\UserForms\Model\UserDefinedForm:
     CLEARBUTTON: پاک‌کردن
     CONFIGURATION: پیکربندی
+    CONFIRMATIONPAGE: 'صفحه تأیید سفارشی'
     DISABLECSRFSECURITYTOKEN: 'غیر فعال کردن CSRF'
     EMAILADDRESS: ایمیل
     EMAILFROM: از

--- a/lang/fi_FI.yml
+++ b/lang/fi_FI.yml
@@ -234,6 +234,7 @@ fi_FI:
     CLASS_DESCRIPTION: 'Lisää kustomoitavan lomakkeen.'
     CLEARBUTTON: Tyhjennä
     CONFIGURATION: Asetukset
+    CONFIRMATIONPAGE: 'Mukautettu vahvistussivu'
     DESCRIPTION: 'Lisää kustomoitavan lomakkeen.'
     DISABLEAUTHENICATEDFINISHACTION: 'Poista Autentikointi viimeistelytoiminnosta'
     DISABLECSRFSECURITYTOKEN: 'Poista CSRF Token'

--- a/lang/fr.yml
+++ b/lang/fr.yml
@@ -302,6 +302,7 @@ fr:
   SilverStripe\UserForms\Model\UserDefinedForm:
     ADDEMAILRECIPIENT: 'Ajouter un mail de destination'
     CLEARBUTTON: Effacer
+    CONFIRMATIONPAGE: 'Page de confirmation personnalisée'
     DISABLEAUTHENICATEDFINISHACTION: "Désactiver l'authentification à la fin de l'action"
     DISABLECSRFSECURITYTOKEN: 'Désactiver le jeton CSRF'
     DISPLAYERRORMESSAGESATTOP: "Afficher les messages d'erreur au dessus du formulaire"

--- a/lang/hr.yml
+++ b/lang/hr.yml
@@ -54,5 +54,6 @@ hr:
   SilverStripe\UserForms\Model\UserDefinedForm:
     CLEARBUTTON: Očisti
     CONFIGURATION: Konfiguracija
+    CONFIRMATIONPAGE: 'Stranica za potvrdu'
     EMAILFROM: Od
     PLURALNAME: 'Osnovne stranice'

--- a/lang/id.yml
+++ b/lang/id.yml
@@ -50,6 +50,7 @@ id:
     db_Value: Nilai
     has_one_Parent: Induk
   SilverStripe\UserForms\Model\UserDefinedForm:
+    CONFIRMATIONPAGE: 'Halaman konfirmasi kustom'
     EMAILFROM: Dari
     EMAILSUBJECT: 'Subyek email'
     PLURALNAME: 'Laman Dasar'

--- a/lang/it.yml
+++ b/lang/it.yml
@@ -195,6 +195,7 @@ it:
     CLASS_DESCRIPTION: 'Aggiungi un modulo personalizzabile.'
     CLEARBUTTON: Azzera
     CONFIGURATION: Configurazione
+    CONFIRMATIONPAGE: 'Pagina di conferma personalizzata'
     DESCRIPTION: 'Aggiungi un modulo personalizzabile.'
     DISABLEAUTHENICATEDFINISHACTION: "Disabilita autenticazione sull'azione finale"
     DISABLECSRFSECURITYTOKEN: 'Disabilita token CSRF'

--- a/lang/ja.yml
+++ b/lang/ja.yml
@@ -109,6 +109,7 @@ ja:
     db_Value: 数値
   SilverStripe\UserForms\Model\UserDefinedForm:
     CLEARBUTTON: クリア
+    CONFIRMATIONPAGE: 'カスタム確認ページ'
     EMAILADDRESS: メール
     EMAILBODY: ボディ
     EMAILBODYHTML: ボディ

--- a/lang/mi.yml
+++ b/lang/mi.yml
@@ -136,6 +136,7 @@ mi:
     ADDEMAILRECIPIENT: 'Tāpiri Kaiwhirhi Īmēra'
     CLASS_DESCRIPTION: 'Ka tāpiri i te puka ka taea te whakarite.'
     CONFIGURATION: Whirihoranga
+    CONFIRMATIONPAGE: 'Whārangi whakaū ritenga ake'
     DESCRIPTION: 'Ka tāpiri i te puka ka taea te whakarite.'
     EMAILADDRESS: Īmēra
     EMAILBODY: Tinana

--- a/lang/nb_NO.yml
+++ b/lang/nb_NO.yml
@@ -102,6 +102,7 @@ nb_NO:
     ADDEMAILRECIPIENT: 'Legg til e-post mottaker'
     CLASS_DESCRIPTION: 'Legg til konfigurerbart skjema'
     CONFIGURATION: Konfigurasjon
+    CONFIRMATIONPAGE: 'Egendefinert bekreftelsesside'
     DESCRIPTION: 'Legg til konfigurerbart skjema'
     EMAILADDRESS: Epost
     EMAILFROM: Fra

--- a/lang/nl.yml
+++ b/lang/nl.yml
@@ -349,6 +349,7 @@ nl:
     CLASS_DESCRIPTION: 'Zelf-instelbaar formulier.'
     CLEARBUTTON: Wissen
     CONFIGURATION: Configuratie
+    CONFIRMATIONPAGE: 'Aangepaste bevestigingspagina'
     DESCRIPTION: 'Zelf-instelbaar formulier.'
     DISABLEAUTHENICATEDFINISHACTION: 'Bedanktpagina toegankelijk maken zonder formulier-inzending'
     DISABLECSRFSECURITYTOKEN: 'CSRF-token uitschakelen'

--- a/lang/pl.yml
+++ b/lang/pl.yml
@@ -47,6 +47,7 @@ pl:
     db_Title: Tytuł
   SilverStripe\UserForms\Model\UserDefinedForm:
     CLEARBUTTON: Wyczyść
+    CONFIRMATIONPAGE: 'Strona potwierdzenia'
     EMAILFROM: Od
     PLURALNAME: 'Podstawowe strony'
     RECIPIENTS: Odbiorcy

--- a/lang/ru.yml
+++ b/lang/ru.yml
@@ -65,6 +65,7 @@ ru:
   SilverStripe\UserForms\Model\UserDefinedForm:
     CLEARBUTTON: Сбросить
     CONFIGURATION: Конфигурация
+    CONFIRMATIONPAGE: 'Пользовательская страница подтверждения'
     EMAILFROM: От
     EMAILSUBJECT: 'Тема письма'
     PLURALNAME: 'Базовые страницы'

--- a/lang/sk.yml
+++ b/lang/sk.yml
@@ -193,6 +193,7 @@ sk:
     CLASS_DESCRIPTION: 'Umožňuje vytvoriť užívateľom definovaný formulár.'
     CLEARBUTTON: Vyčistiť
     CONFIGURATION: Konfigurácia
+    CONFIRMATIONPAGE: 'Vlastná potvrdzovacia stránka'
     DESCRIPTION: 'Umožňuje vytvoriť užívateľom definovaný formulár.'
     DISABLEAUTHENICATEDFINISHACTION: 'Zakázať autentifikáciu po odoslaní formulára?'
     DISABLECSRFSECURITYTOKEN: 'Zakázať CSRF token?'

--- a/lang/sl.yml
+++ b/lang/sl.yml
@@ -404,6 +404,7 @@ sl:
     CLASS_DESCRIPTION: 'Doda prilagojen obrazec.'
     CLEARBUTTON: Ponastavi
     CONFIGURATION: Nastavitve
+    CONFIRMATIONPAGE: 'Stran za potrditev po meri'
     DESCRIPTION: 'Doda prilagojen obrazec.'
     DISABLEAUTHENICATEDFINISHACTION: 'Onemogoči avtentikacijo na koncu.'
     DISABLECSRFSECURITYTOKEN: 'Onemogoči CSRF žeton'

--- a/lang/sv.yml
+++ b/lang/sv.yml
@@ -146,6 +146,7 @@ sv:
     CLASS_DESCRIPTION: 'Lägger till ett konfigurerbart formulär'
     CLEARBUTTON: Rensa
     CONFIGURATION: Konfiguration
+    CONFIRMATIONPAGE: 'Anpassad bekräftelsesida'
     DESCRIPTION: 'Lägger till ett konfigurerbart formulär'
     DISABLECSRFSECURITYTOKEN: 'Inaktivera CSRF-tecken'
     EMAILADDRESS: E-post

--- a/lang/zh.yml
+++ b/lang/zh.yml
@@ -140,6 +140,7 @@ zh:
     CLASS_DESCRIPTION: 添加一个可定制的表格。
     CLEARBUTTON: 清除
     CONFIGURATION: 配置
+    CONFIRMATIONPAGE: '自定义确认页面'
     DESCRIPTION: 添加一个可定制的表格。
     EMAILADDRESS: 电子邮件
     EMAILBODY: 正文


### PR DESCRIPTION
## Description

Add a new option to the Userform configuration: Custom confirmation page.

If this field contains a valid PageID from the SiteTree, when a form is successfully submitted in the frontend, the browser is redirected to the given page.

This allows form confirmation pages to be built individually, using all available content blocks (on an elemental page), allowing more flexibility/variety.


## Manual testing steps

- Create or edit a userform
- Open the configuration tab
- Select any page in the new field "custom confirmation page"
- Fill out and submit the form in the frontend

If there's no validation errors, you will be redirected to the selected confirmation page.


## Issues
- #1376 

## Pull request checklist
- [x] The target branch is correct
- [x] All commits are relevant to the purpose of the PR (e.g. no debug statements, unrelated refactoring, or arbitrary linting)
- [i] The commit messages follow our commit message guidelines 
Note: Commit message is missing the ENH prefix. This was discovered after the change was already pushed. Changing the commit message (using rebase) will probably do more harm than good, so we decided against it. Please check if this is a show stopper for this PR
- [x] The PR follows our [contribution guidelines](https://docs.silverstripe.org/en/contributing/code/)
- [x] Code changes follow our [coding conventions](https://docs.silverstripe.org/en/contributing/coding_conventions/)
- [x] This change is covered with tests (or tests aren't necessary for this change)
- [x] Any relevant User Help/Developer documentation is updated; for impactful changes, information is added to the changelog for the intended release
- [x] CI is green
