### PR TITLE
ENH Use new DataList caching

### DIFF
--- a/code/Control/UserDefinedFormAdmin.php
+++ b/code/Control/UserDefinedFormAdmin.php
@@ -296,7 +296,7 @@ class UserDefinedFormAdmin extends FormSchemaController
         $formSubmissionsFolder = Folder::find(static::config()->get('form_submissions_folder'));
         $formSubmissionsFolder->CanViewType = InheritedPermissions::ONLY_THESE_USERS;
         $formSubmissionsFolder->ViewerGroups()->removeAll();
-        $formSubmissionsFolder->ViewerGroups()->add(Group::get_one(Group::class, ['"Code"' => 'administrators']));
+        $formSubmissionsFolder->ViewerGroups()->add(Group::get()->setUseCache(true)->find('Code', 'administrators'));
         $formSubmissionsFolder->write();
     }
 

--- a/code/Model/EditableFormField.php
+++ b/code/Model/EditableFormField.php
@@ -954,7 +954,7 @@ class EditableFormField extends DataObject
         // Check for field dependencies / default
         foreach ($this->DisplayRules() as $rule) {
             // Get the field which is effected
-            $formFieldWatch = DataObject::get_by_id(EditableFormField::class, $rule->ConditionFieldID);
+            $formFieldWatch = EditableFormField::get()->setUseCache(true)->byID($rule->ConditionFieldID);
             // Skip deleted fields
             if (!$formFieldWatch) {
                 continue;

--- a/composer.json
+++ b/composer.json
@@ -31,7 +31,7 @@
     ],
     "require": {
         "php": "^8.3",
-        "silverstripe/framework": "^6",
+        "silverstripe/framework": "^6.1",
         "silverstripe/cms": "^6",
         "symbiote/silverstripe-gridfieldextensions": "^5",
         "silverstripe/segment-field": "^4",

--- a/tests/php/Control/UserDefinedFormControllerTest.php
+++ b/tests/php/Control/UserDefinedFormControllerTest.php
@@ -499,7 +499,7 @@ class UserDefinedFormControllerTest extends FunctionalTest
 
         $controller->process($data, $controller->Form());
 
-        $field = EditableFileField::get_by_id($field->ID);
+        $field = EditableFileField::get()->setUseCache(true)->byID($field->ID);
         $filter = [
             'ParentID' => $field->Folder()->ID,
             'Name' => 'testfile.jpg',


### PR DESCRIPTION
Replaces deprecated `DataObject::get_one()` and `DataObject::get_by_id()` in favour of the new DataList query caching.

> [!IMPORTANT]
> Relies on https://github.com/silverstripe/silverstripe-framework/pull/11768
> DO NOT MERGE until that PR has been merged in

## Issue

- https://github.com/silverstripe/silverstripe-framework/issues/11767
