### PR TITLE
Remove user_error when trying to use a form field without a getFormField()

### DIFF
--- a/code/Extension/UserFormFieldEditorExtension.php
+++ b/code/Extension/UserFormFieldEditorExtension.php
@@ -60,7 +60,7 @@ class UserFormFieldEditorExtension extends DataExtension
     {
         $fieldEditor = $this->getFieldEditorGrid();
 
-        $fields->insertAfter('Main', Tab::create('FormFields', _t(__CLASS__.'.FORMFIELDS', 'Form Fields')));
+        $fields->insertAfter('Main', Tab::create('FormFields', _t(__CLASS__ . '.FORMFIELDS', 'Form Fields')));
         $fields->addFieldToTab('Root.FormFields', $fieldEditor);
 
         return $fields;
@@ -90,6 +90,11 @@ class UserFormFieldEditorExtension extends DataExtension
                     if ($record instanceof EditableFileField) {
                         $field->setAttribute('data-folderconfirmed', $record->FolderConfirmed ? 1 : 0);
                     }
+
+                    if ($record->getObsoleteClassName()) {
+                        $field->setEmptyString(_t(__CLASS__ . '.OBSOLETE_CLASS', '(Obsolete Class)'));
+                    }
+
                     return $field;
                 }
             },
@@ -105,13 +110,13 @@ class UserFormFieldEditorExtension extends DataExtension
                 $editableColumns,
                 GridFieldButtonRow::create(),
                 (new GridFieldAddClassesButton(EditableTextField::class))
-                    ->setButtonName(_t(__CLASS__.'.ADD_FIELD', 'Add Field'))
+                    ->setButtonName(_t(__CLASS__ . '.ADD_FIELD', 'Add Field'))
                     ->setButtonClass('btn-primary'),
                 (new GridFieldAddClassesButton(EditableFormStep::class))
-                    ->setButtonName(_t(__CLASS__.'.ADD_PAGE_BREAK', 'Add Page Break'))
+                    ->setButtonName(_t(__CLASS__ . '.ADD_PAGE_BREAK', 'Add Page Break'))
                     ->setButtonClass('btn-secondary'),
                 (new GridFieldAddClassesButton([EditableFieldGroup::class, EditableFieldGroupEnd::class]))
-                    ->setButtonName(_t(__CLASS__.'.ADD_FIELD_GROUP', 'Add Field Group'))
+                    ->setButtonName(_t(__CLASS__ . '.ADD_FIELD_GROUP', 'Add Field Group'))
                     ->setButtonClass('btn-secondary'),
                 $editButton = GridFieldEditButton::create(),
                 GridFieldDeleteAction::create(),

--- a/code/FormField/UserFormsCompositeField.php
+++ b/code/FormField/UserFormsCompositeField.php
@@ -40,10 +40,13 @@ abstract class UserFormsCompositeField extends CompositeField implements UserFor
         if (get_class($field) === EditableFormField::class || !$field->getFormField()) {
             return $this;
         }
+
         $formField = $field->getFormField();
 
         // Save this field
-        $this->push($formField);
+        if ($formField) {
+            $this->push($formField);
+        }
 
         // Nest fields that are containers
         if ($formField instanceof UserFormsFieldContainer) {

--- a/code/Model/EditableFormField.php
+++ b/code/Model/EditableFormField.php
@@ -2,6 +2,7 @@
 
 namespace SilverStripe\UserForms\Model;
 
+use Psr\Log\LoggerInterface;
 use SilverStripe\CMS\Controllers\CMSMain;
 use SilverStripe\CMS\Controllers\CMSPageEditController;
 use SilverStripe\Control\Controller;
@@ -13,6 +14,7 @@ use SilverStripe\Forms\CheckboxField;
 use SilverStripe\Forms\DropdownField;
 use SilverStripe\Forms\FieldList;
 use SilverStripe\Forms\FormField;
+use SilverStripe\Core\Injector\Injector;
 use SilverStripe\Forms\GridField\GridField;
 use SilverStripe\Forms\GridField\GridFieldButtonRow;
 use SilverStripe\Forms\GridField\GridFieldConfig;
@@ -720,11 +722,17 @@ class EditableFormField extends DataObject
      * Return a FormField to appear on the front end. Implement on
      * your subclass.
      *
-     * @return FormField
+     * @return FormField|null
      */
     public function getFormField()
     {
-        user_error("Please implement a getFormField() on your EditableFormClass ". $this->ClassName, E_USER_ERROR);
+        Injector::inst()->get(LoggerInterface::class)
+            ->warning(
+                'EditableFormField::getFormField() should be implemented in a subclass',
+                ['class' => static::class]
+            );
+
+        return null;
     }
 
     /**

--- a/code/Model/EditableFormField/EditableCountryDropdownField.php
+++ b/code/Model/EditableFormField/EditableCountryDropdownField.php
@@ -85,7 +85,13 @@ class EditableCountryDropdownField extends EditableFormField
     public function getValueFromData($data)
     {
         if (!empty($data[$this->Name])) {
-            $source = $this->getFormField()->getSource();
+            $field = $this->getFormField();
+
+            if (!$field) {
+                return null;
+            }
+
+            $source = $field->getSource();
             return $source[$data[$this->Name]];
         }
     }


### PR DESCRIPTION
## Description


## Manual testing steps

- create a new EditableFormField class (SuperTextField)
- create a UserForm with one of these fields
- publish page
- rejoice!
- remove SuperTextField class from codebase
- note that the field has been changed to a CheckboxField (I assume this is just the first one in the list?)
- attempt to Publish again

## Issues

- https://github.com/silverstripe/silverstripe-userforms/issues/1086

## Pull request checklist

- [x] The target branch is correct
    - See [picking the right version](https://docs.silverstripe.org/en/contributing/code/#picking-the-right-version)
- [x] All commits are relevant to the purpose of the PR (e.g. no debug statements, unrelated refactoring, or arbitrary linting)
    - Small amounts of additional linting are usually okay, but if it makes it hard to concentrate on the relevant changes, ask for the unrelated changes to be reverted, and submitted as a separate PR.
- [x] The commit messages follow our [commit message guidelines](https://docs.silverstripe.org/en/contributing/code/#commit-messages)
- [x] The PR follows our [contribution guidelines](https://docs.silverstripe.org/en/contributing/code/)
- [x] Code changes follow our [coding conventions](https://docs.silverstripe.org/en/contributing/coding_conventions/)
- [x] This change is covered with tests (or tests aren't necessary for this change)
- [x] Any relevant User Help/Developer documentation is updated; for impactful changes, information is added to the changelog for the intended release
- [x] CI is green
