### PR TITLE
FIX Redirect back when file validation fails.

### DIFF
--- a/code/Control/UserDefinedFormController.php
+++ b/code/Control/UserDefinedFormController.php
@@ -327,8 +327,7 @@ JS
                                 foreach ($validationResult->getMessages() as $message) {
                                     $form->sessionMessage($message['message'], ValidationResult::TYPE_ERROR);
                                 }
-                                Controller::curr()->redirectBack();
-                                return null;
+                                return $this->redirectBack();
                             }
                             /** @var AssetContainer|File $file */
                             $file = $upload->getFile();

--- a/tests/php/Control/UserDefinedFormControllerTest.php
+++ b/tests/php/Control/UserDefinedFormControllerTest.php
@@ -525,6 +525,62 @@ class UserDefinedFormControllerTest extends FunctionalTest
         $this->assertSame(5 * 1024 * 1024, $udfController->getMaximumAllowedEmailAttachmentSize());
     }
 
+    /**
+     * Test that file validation failures properly redirect back to the form
+     * instead of returning null. This ensures users see the validation error
+     * rather than encountering a broken page.
+     *
+     * Regression test for fix where redirectBack() was called but null was returned,
+     * preventing the redirect from executing.
+     */
+    public function testFileValidationFailureRedirectsBack()
+    {
+        Config::modify()->set(Upload_Validator::class, 'use_is_uploaded_file', false);
+
+        // Set extremely small max file size to trigger validation failure
+        Config::modify()->set(Upload_Validator::class, 'default_max_file_size', 1);
+
+        $userForm = $this->setupFormFrontend('upload-form');
+        $controller = new UserDefinedFormController($userForm);
+        $field = $this->objFromFixture(EditableFileField::class, 'file-field-1');
+
+        // Use existing test file which will exceed the 1 byte limit
+        $path = realpath(__DIR__ . '/fixtures/testfile.jpg');
+        $data = [
+            $field->Name => [
+                'name' => 'testfile.jpg',
+                'type' => 'image/jpeg',
+                'tmp_name' => $path,
+                'error' => 0,
+                'size' => filesize($path ?? ''),
+            ]
+        ];
+        $_FILES[$field->Name] = $data[$field->Name];
+
+        $controller->getRequest()->setSession(new Session([]));
+
+        // Process the form - this should trigger validation failure
+        $response = $controller->process($data, $controller->Form());
+
+        // Critical: Response must not be null (the bug being fixed)
+        $this->assertInstanceOf(HTTPResponse::class, $response,
+            'Response should be HTTPResponse, not null, when file validation fails');
+
+        // Assert it's a redirect (302)
+        $this->assertEquals(302, $response->getStatusCode(),
+            'Should redirect back to form on validation failure');
+
+        // Assert we don't redirect to the 'finished' success page
+        $location = $response->getHeader('Location');
+        $this->assertStringNotContainsString('finished', $location,
+            'Should not redirect to success page when validation fails');
+
+        // Assert no file was created in the database
+        $uploadedFiles = File::get()->filter(['Name:StartsWith' => 'testfile']);
+        $this->assertEquals(0, $uploadedFiles->count(),
+            'No file should be created when validation fails');
+    }
+
     public function getParseByteSizeStringTestValues()
     {
         return [


### PR DESCRIPTION
## Description
When file validation fails the user should be redirected back to the form, `Controller::curr()->redirectBack();` doesn't perform the actual redirect but provides the redirect response. Therefore the response should be returned, not a `null`.

## Manual testing steps
Setup a userform with a file field and upload a file that fails validation, you should be redirected back to the form with an error message.

## Issues
- #1415

## Pull request checklist
<!--
  PLEASE check each of these to ensure you have done everything you need to do!
  If there's something in this list you need help with, please ask so that we can assist you.
-->
- [x] The target branch is correct
    - See [picking the right version](https://docs.silverstripe.org/en/contributing/code/#picking-the-right-version)
- [x] All commits are relevant to the purpose of the PR (e.g. no debug statements, unrelated refactoring, or arbitrary linting)
    - Small amounts of additional linting are usually okay, but if it makes it hard to concentrate on the relevant changes, ask for the unrelated changes to be reverted, and submitted as a separate PR.
- [x] The commit messages follow our [commit message guidelines](https://docs.silverstripe.org/en/contributing/code/#commit-messages)
- [x] The PR follows our [contribution guidelines](https://docs.silverstripe.org/en/contributing/code/)
- [x] Code changes follow our [coding conventions](https://docs.silverstripe.org/en/contributing/coding_conventions/)
- [ ] This change is covered with tests (or tests aren't necessary for this change)
- [x] Any relevant User Help/Developer documentation is updated; for impactful changes, information is added to the changelog for the intended release
- [ ] CI is green
