### PR TITLE
ENH PHP 8.5 Support

### DIFF
--- a/code/Model/Recipient/EmailRecipient.php
+++ b/code/Model/Recipient/EmailRecipient.php
@@ -533,8 +533,7 @@ class EmailRecipient extends DataObject
      */
     public function emailTemplateExists($template = '')
     {
-        $t = ($template ? $template : $this->EmailTemplate);
-
+        $t = ($template ? $template : $this->EmailTemplate) ?? '';
         return array_key_exists($t, (array) $this->getEmailTemplateDropdownValues());
     }
 

--- a/tests/behat/features/userforms.feature
+++ b/tests/behat/features/userforms.feature
@@ -71,6 +71,7 @@ Feature: Userforms
     Then I drag the ".ss-gridfield-item[data-id='4'] .handle" element to the ".ss-gridfield-item[data-id='6'] .handle" element
     And I wait for 1 seconds
     And I press the "Publish" button
+    And I wait for 1 seconds
     And I dismiss all toasts
 
     # Add email recipient with custom text and custom rules

--- a/tests/php/Control/UserDefinedFormControllerTest.php
+++ b/tests/php/Control/UserDefinedFormControllerTest.php
@@ -631,8 +631,6 @@ class UserDefinedFormControllerTest extends FunctionalTest
     {
         $class = new ReflectionClass(UserDefinedFormController::class);
         $method = $class->getMethod('validEmailsToArray');
-        $method->setAccessible(true);
-
         $controller = new UserDefinedFormController();
 
         $this->assertEquals($expected, $method->invokeArgs($controller, $input));

--- a/tests/php/Model/EditableFormField/EditableFileFieldTest.php
+++ b/tests/php/Model/EditableFormField/EditableFileFieldTest.php
@@ -84,7 +84,7 @@ class EditableFileFieldTest extends SapphireTest
         $defaultFolder = Folder::find('Form-submissions');
         $this->assertNotEmpty($defaultFolder, 'Default Folder was created along with the EditableFileField');
         $this->assertFalse($defaultFolder->canView(), 'Default Folder default to being restricted');
-        $this->assertFalse((boolean)$fileField->FolderConfirmed, 'EditableFileField are not Folder Confirmed initially');
+        $this->assertFalse((bool) $fileField->FolderConfirmed, 'EditableFileField are not Folder Confirmed initially');
 
         $this->assertEquals(
             $defaultFolder->ID,
@@ -95,7 +95,7 @@ class EditableFileFieldTest extends SapphireTest
         $fileField->FolderID = Folder::find_or_make('boom')->ID;
         $fileField->write();
         $this->assertTrue(
-            (boolean)$fileField->FolderConfirmed,
+            (bool) $fileField->FolderConfirmed,
             'EditableFileField are Folder Confirmed once you assigned them a folder'
         );
 


### PR DESCRIPTION
Issue https://github.com/silverstripe/.github/issues/455

The following changes were made based on the [PHP 8.5 changelog](https://www.php.net/ChangeLog-8.php):

- The setAccessible() methods of various Reflection objects have been deprecated, as those no longer have an effect.
- Using null as an array offset or when calling array_key_exists() is now deprecated.
- Non-canonical cast names (boolean), (integer), (double), and (binary) have been deprecated.
