### PR TITLE
ENH performance improvement for writing editableformfields

### DIFF
--- a/code/Model/EditableFormField.php
+++ b/code/Model/EditableFormField.php
@@ -428,9 +428,11 @@ class EditableFormField extends DataObject
     {
         parent::onBeforeWrite();
 
-        $formField = $this->getFormField();
-        if ($formField && !$formField->hasData()) {
-            $this->Required = false;
+        if ($this->Required && $this->isChanged('Required', DataObject::CHANGE_VALUE)) {
+            $formField = $this->getFormField();
+            if ($formField && !$formField->hasData()) {
+                $this->Required = false;
+            }
         }
 
         // Set a field name.


### PR DESCRIPTION
## Description
The onBeforeWrite function for EditableFormField checks whether the frontend form field has data or not, and if not, sets Required to false. Getting the frontend form field can be expensive in performance for a large number of fields in a single form, but we only really need to do that if we're currently trying to set Required to true.

Adding a check for this brought the write time of a userform in one of our sites (with about 80 fields) down from 60+ seconds into the range of ~5 seconds.

## Manual testing steps
On a userform and/or elementform, compare the time it takes to save and/or publish with a large number of fields.

## Issues
- Relevant to https://github.com/silverstripe/silverstripe-userforms/issues/773

## Pull request checklist
<!--
  PLEASE check each of these to ensure you have done everything you need to do!
  If there's something in this list you need help with, please ask so that we can assist you.
-->
- [X] The target branch is correct
    - See [picking the right version](https://docs.silverstripe.org/en/contributing/code/#picking-the-right-version)
- [X] All commits are relevant to the purpose of the PR (e.g. no debug statements, unrelated refactoring, or arbitrary linting)
    - Small amounts of additional linting are usually okay, but if it makes it hard to concentrate on the relevant changes, ask for the unrelated changes to be reverted, and submitted as a separate PR.
- [X] The commit messages follow our [commit message guidelines](https://docs.silverstripe.org/en/contributing/code/#commit-messages)
- [X] The PR follows our [contribution guidelines](https://docs.silverstripe.org/en/contributing/code/)
- [X] Code changes follow our [coding conventions](https://docs.silverstripe.org/en/contributing/coding_conventions/)
- [X] This change is covered with tests (or tests aren't necessary for this change)
- [X] Any relevant User Help/Developer documentation is updated; for impactful changes, information is added to the changelog for the intended release
- [X] CI is green
