### PR TITLE
DOC Correct typos with codespell

### DIFF
--- a/client/src/bundles/UserForms.js
+++ b/client/src/bundles/UserForms.js
@@ -217,7 +217,7 @@ jQuery(document).ready(($) => {
       });
     }
 
-    // Ensure that page visibilty updates the step navigation
+    // Ensure that page visibility updates the step navigation
     this
       .$elButton
       .on('userform.field.hide userform.field.show', () => {
@@ -514,7 +514,7 @@ jQuery(document).ready(($) => {
       }, 0);
     },
     // Callback for handling the actual submit when the form is valid.
-    // Submission in the jQuery.validate sence is handled at step level.
+    // Submission in the jQuery.validate sense is handled at step level.
     // So when the final step is submitted we have to also check all previous steps are valid.
     submitHandler: (form) => {
       let isValid = true;
@@ -631,7 +631,7 @@ jQuery(document).ready(($) => {
     }
 
     // Validate the form.
-    // This well effectivly validate the current step and not the entire form.
+    // This will effectively validate the current step and not the entire form.
     // This is because hidden fields are excluded from validation, and all fields
     // on all other steps, are currently hidden.
     isValid = this.$el.valid();

--- a/code/Control/UserDefinedFormAdmin.php
+++ b/code/Control/UserDefinedFormAdmin.php
@@ -77,7 +77,7 @@ class UserDefinedFormAdmin extends FormSchemaController
 
     public function index(HTTPRequest $request): HTTPResponse
     {
-        // Don't serve anythign under the main URL.
+        // Don't serve anything under the main URL.
         return $this->httpError(404);
     }
 
@@ -146,7 +146,7 @@ class UserDefinedFormAdmin extends FormSchemaController
     }
 
     /**
-     * Return the ConfirmFolderForm. This is only exposed so the treeview has somewhere to direct it's AJAX calss.
+     * Return the ConfirmFolderForm. This is only exposed so the treeview has somewhere to direct it's AJAX calls.
      * @return Form
      */
     public function ConfirmFolderForm(): Form
@@ -287,7 +287,7 @@ class UserDefinedFormAdmin extends FormSchemaController
     }
 
     /**
-     * Set the permission for the default submisison folder.
+     * Set the permission for the default submission folder.
      * @throws ValidationException
      */
     private static function updateFormSubmissionFolderPermissions()

--- a/code/Control/UserDefinedFormController.php
+++ b/code/Control/UserDefinedFormController.php
@@ -58,7 +58,7 @@ class UserDefinedFormController extends PageController
     private static string $file_upload_stage = Versioned::DRAFT;
 
     /**
-     * Size that an uploaded file must not excede for it to be attached to an email
+     * Size that an uploaded file must not exceed for it to be attached to an email
      * Follows PHP "shorthand bytes" definition rules.
      * @see UserDefinedFormController::parseByteSizeString()
      *
@@ -100,7 +100,7 @@ class UserDefinedFormController extends PageController
     }
 
     /**
-     * Add the necessary jQuery validate i18n translation files, either by locale or by langauge,
+     * Add the necessary jQuery validate i18n translation files, either by locale or by language,
      * e.g. 'en_NZ' or 'en'. This adds "methods_abc.min.js" as well as "messages_abc.min.js" from the
      * jQuery validate thirdparty library from dist/js.
      */
@@ -453,7 +453,7 @@ JS
                     $email->setFrom($this->validEmailsToArray($recipient->EmailFrom));
                 }
 
-                // check to see if they are a dynamic reciever eg based on a dropdown field a user selected
+                // check to see if they are a dynamic receiver eg based on a dropdown field a user selected
                 $emailTo = $recipient->SendEmailToField();
 
                 try {
@@ -542,7 +542,7 @@ JS
                 $session->set('FormProcessed', $data['SecurityID']);
             } else {
                 // if the form has had tokens disabled we still need to set FormProcessed
-                // to allow us to get through the finshed method
+                // to allow us to get through the finished method
                 if (!$this->Form()->getSecurityToken()->isEnabled()) {
                     $randNum = rand(1, 1000);
                     $randHash = md5($randNum ?? '');
@@ -660,7 +660,7 @@ JS
 EOS;
             if ($isFormStep) {
                 // Hide the step jump button if the FormStep has is initially hidden.
-                // This is particularly important beacause the next/prev page buttons logic is controlled by
+                // This is particularly important because the next/prev page buttons logic is controlled by
                 // the visibility of the FormStep buttons
                 // The HTML for the FormStep buttons is defined in the UserFormProgress template
                 $id = str_replace('#', '', $target ?? '');

--- a/code/Form/GridFieldAddClassesButton.php
+++ b/code/Form/GridFieldAddClassesButton.php
@@ -30,7 +30,7 @@ class GridFieldAddClassesButton implements GridField_HTMLProvider, GridField_Act
     protected $buttonName;
 
     /**
-     * Additonal CSS classes for the button
+     * Additional CSS classes for the button
      *
      * @var string
      */

--- a/code/Model/EditableFormField.php
+++ b/code/Model/EditableFormField.php
@@ -1020,7 +1020,7 @@ class EditableFormField extends DataObject
         foreach ($displayRules as $rule) {
             $controllingField = $rule->ConditionField();
 
-            // recursively check - if any of the dependant fields are hidden, assume the rule can not be satisfied
+            // recursively check - if any of the dependent fields are hidden, assume the rule can not be satisfied
             $ruleSatisfied = $this->checkIsDisplayedRecursionProtection()
             && $controllingField->isDisplayed($data)
             && $rule->validateAgainstFormData($data);

--- a/tests/behat/features/userforms.feature
+++ b/tests/behat/features/userforms.feature
@@ -108,7 +108,7 @@ Feature: Userforms
     And I should not see "My textfield 2"
     And I should not see "My textfield 3"
 
-    # Pressing '2' buton should do nothing at this stage
+    # Pressing '2' button should do nothing at this stage
     When I press the "2" button
     Then I should see "First Page"
 

--- a/tests/php/Control/UserDefinedFormAdminTest.php
+++ b/tests/php/Control/UserDefinedFormAdminTest.php
@@ -192,7 +192,7 @@ class UserDefinedFormAdminTest extends FunctionalTest
         $fieldID = $this->idFromFixture(EditableFileField::class, 'file-field-1');
 
         $response = $this->post($url, ['ID' => $fieldID, 'FolderOptions' => 'existing', 'FolderID' => -1]);
-        $this->assertEquals(400, $response->getStatusCode(), 'Confirm a non-existant folder fails with 400');
+        $this->assertEquals(400, $response->getStatusCode(), 'Confirm a non-existent folder fails with 400');
     }
 
     public function testConfirmfolderRootFolder()

--- a/tests/php/Model/UserDefinedFormTest.php
+++ b/tests/php/Model/UserDefinedFormTest.php
@@ -68,8 +68,8 @@ class UserDefinedFormTest extends FunctionalTest
 
         $form->rollbackRecursive($origVersion);
 
-        $orignal = Versioned::get_one_by_stage(UserDefinedForm::class, 'Stage', "\"UserDefinedForm\".\"ID\" = $form->ID");
-        $this->assertEquals($orignal->SubmitButtonText, 'Button Text');
+        $original = Versioned::get_one_by_stage(UserDefinedForm::class, 'Stage', "\"UserDefinedForm\".\"ID\" = $form->ID");
+        $this->assertEquals($original->SubmitButtonText, 'Button Text');
     }
 
     public function testGetCMSFields()


### PR DESCRIPTION
Source code (5 files):
- Additonal → Additional (GridFieldAddClassesButton.php)
- dependant → dependent (EditableFormField.php)
- anythign → anything (UserDefinedFormAdmin.php)
- calss → calls (UserDefinedFormAdmin.php)
- submisison → submission (UserDefinedFormAdmin.php)
- excede → exceed (UserDefinedFormController.php)
- langauge → language (UserDefinedFormController.php)
- reciever → receiver (UserDefinedFormController.php)
- finshed → finished (UserDefinedFormController.php)
- beacause → because (UserDefinedFormController.php)

Client source (1 file):
- visibilty → visibility (UserForms.js)
- sence → sense (UserForms.js)
- effectivly → effectively (UserForms.js)

Tests (3 files):
- buton → button (userforms.feature)
- non-existant → non-existent (UserDefinedFormAdminTest.php)
- orignal → original (UserDefinedFormTest.php)

All changes are to comments, documentation, test files, and test variables. No functional code changes.

## Pull request checklist
- [x] The target branch is correct
    - See [picking the right version](https://docs.silverstripe.org/en/contributing/code/#picking-the-right-version)
- [x] All commits are relevant to the purpose of the PR (e.g. no debug statements, unrelated refactoring, or arbitrary linting)
    - Small amounts of additional linting are usually okay, but if it makes it hard to concentrate on the relevant changes, ask for the unrelated changes to be reverted, and submitted as a separate PR.
- [x] The commit messages follow our [commit message guidelines](https://docs.silverstripe.org/en/contributing/code/#commit-messages)
- [x] The PR follows our [contribution guidelines](https://docs.silverstripe.org/en/contributing/code/)
- [ ] Code changes follow our [coding conventions](https://docs.silverstripe.org/en/contributing/coding_conventions/)
- [ ] This change is covered with tests (or tests aren't necessary for this change)
- [ ] Any relevant User Help/Developer documentation is updated; for impactful changes, information is added to the changelog for the intended release
- [x] CI is green
