### PR TITLE
FIX: Prevent frontend JS/CSS from loading in CMS admin context

### DIFF
--- a/code/Control/UserDefinedFormController.php
+++ b/code/Control/UserDefinedFormController.php
@@ -5,6 +5,7 @@ namespace SilverStripe\UserForms\Control;
 use Exception;
 use PageController;
 use Psr\Log\LoggerInterface;
+use SilverStripe\Admin\LeftAndMain;
 use SilverStripe\AssetAdmin\Controller\AssetAdmin;
 use SilverStripe\Assets\File;
 use SilverStripe\Assets\Upload;
@@ -70,6 +71,11 @@ class UserDefinedFormController extends PageController
     protected function init()
     {
         parent::init();
+
+        // prevent frontend JS/CSS requirements in the admin context (especially jQuery)
+        if (Controller::curr() instanceof LeftAndMain) {
+            return;
+        }
 
         $page = $this->data();
 


### PR DESCRIPTION
## Description
When ElementFormController triggers `UserDefinedFormController::init()` in the CMS (e.g. via elemental block rendering), frontend resources like jQuery are loaded and overwrite the admin's jQuery with entwine attached, causing a cascade of JS errors ($.entwine is not a function).

Add a LeftAndMain guard to skip frontend Requirements in admin context. CMS-side userforms UI (userforms-cms.js) is unaffected as it loads through getCMSFields() paths.

## Steps to reproduce
1. Install `dnadesign/silverstripe-elemental-userforms`
2. Add an `ElementForm` block to any page
3. Set `block_default_userforms_js: false` in config (needed for frontend display rules)
4. Open that page in the CMS admin
5. Observe JS console errors: `$.entwine is not a function`, `tooltip is not a function`, etc.

## Workaround (without this fix)
Setting `block_default_userforms_js: true` prevents the issue but also blocks display rules JS on the frontend.

## Pull request checklist
- [ ] The target branch is correct
    - See [picking the right version](https://docs.silverstripe.org/en/contributing/code/#picking-the-right-version)
- [ ] All commits are relevant to the purpose of the PR (e.g. no debug statements, unrelated refactoring, or arbitrary linting)
    - Small amounts of additional linting are usually okay, but if it makes it hard to concentrate on the relevant changes, ask for the unrelated changes to be reverted, and submitted as a separate PR.
- [ ] The commit messages follow our [commit message guidelines](https://docs.silverstripe.org/en/contributing/code/#commit-messages)
- [ ] The PR follows our [contribution guidelines](https://docs.silverstripe.org/en/contributing/code/)
- [ ] Code changes follow our [coding conventions](https://docs.silverstripe.org/en/contributing/coding_conventions/)
- [ ] This change is covered with tests (or tests aren't necessary for this change)
- [ ] Any relevant User Help/Developer documentation is updated; for impactful changes, information is added to the changelog for the intended release
- [ ] CI is green
