### PR TITLE
[CVE-2026-54721] Prevent RCE via email recipient subject

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -31,7 +31,7 @@
     ],
     "require": {
         "php": "^8.1",
-        "silverstripe/framework": "^5.4",
+        "silverstripe/framework": "^5.4.30",
         "silverstripe/cms": "^5",
         "symbiote/silverstripe-gridfieldextensions": "^4",
         "silverstripe/segment-field": "^3",

--- a/tests/php/Control/UserDefinedFormControllerTest.php
+++ b/tests/php/Control/UserDefinedFormControllerTest.php
@@ -402,6 +402,37 @@ class UserDefinedFormControllerTest extends FunctionalTest
         $this->assertEmailSent('test@example.com', 'no-reply@example.com', 'Email Subject: Basic Value');
     }
 
+    /**
+     * The EmailSubject is rendered as a template. An author controlled subject must never have PHP
+     * within it evaluated (which previously allowed remote code execution via the <%t %> default
+     * string handling). The payload below must be treated as inert text.
+     */
+    public function testRecipientSubjectDoesNotEvaluatePhp()
+    {
+        $form = $this->setupFormFrontend();
+
+        $rceFile = ASSETS_PATH . '/userforms_rce_test.txt';
+        if (file_exists($rceFile ?? '')) {
+            unlink($rceFile ?? '');
+        }
+
+        $recipient = $this->objFromFixture(EmailRecipient::class, 'recipient-1');
+        $recipient->EmailSubject = '<%t Foo "{${\'file_put_contents\'(\''
+            . $rceFile . '\',\'pwned\')}}" %>';
+        $recipient->write();
+
+        $this->autoFollowRedirection = false;
+        $this->clearEmails();
+
+        $this->get($form->URLSegment);
+
+        $field = $this->objFromFixture(EditableTextField::class, 'basic-text');
+        $this->submitForm('UserForm_Form_' . $form->ID, null, [$field->Name => 'Basic Value']);
+
+        // The payload must not have been executed, so no file should have been written.
+        $this->assertFileDoesNotExist($rceFile);
+    }
+
     public function testImageThumbnailCreated()
     {
         Config::modify()->set(Upload_Validator::class, 'use_is_uploaded_file', false);


### PR DESCRIPTION
endtoend failure is only for PHP 8.1 not for PHP 8.3 - CI uses an older version of gha-ci and would have passed if it has [this fix](https://github.com/silverstripe/gha-ci/pull/175) backported (which we won't be backporting)