### PR TITLE
Replaced broken UserFormsGridFieldFilterHeader with a SearchFilter and the default GridFieldFilterHeader

### DIFF
--- a/code/Form/UserFormsGridFieldFilterHeader.php
+++ b/code/Form/UserFormsGridFieldFilterHeader.php
@@ -3,6 +3,7 @@
 namespace SilverStripe\UserForms\Form;
 
 use SilverStripe\Core\Convert;
+use SilverStripe\Dev\Deprecation;
 use SilverStripe\Forms\CompositeField;
 use SilverStripe\Forms\DateField;
 use SilverStripe\Forms\DropdownField;
@@ -12,10 +13,10 @@ use SilverStripe\Forms\GridField\GridField_FormAction;
 use SilverStripe\Forms\GridField\GridFieldDataColumns;
 use SilverStripe\Forms\GridField\GridFieldFilterHeader;
 use SilverStripe\Forms\TextField;
-use SilverStripe\Model\List\ArrayList;
-use SilverStripe\ORM\FieldType\DBDate;
-use SilverStripe\Model\List\SS_List;
 use SilverStripe\Model\ArrayData;
+use SilverStripe\Model\List\ArrayList;
+use SilverStripe\Model\List\SS_List;
+use SilverStripe\ORM\FieldType\DBDate;
 
 /**
  * Extension to the build in SilverStripe {@link GridField} to allow for
@@ -23,6 +24,7 @@ use SilverStripe\Model\ArrayData;
  * entering the value of a field
  *
  * @package userforms
+ * @deprecated 7.2.0 Will be removed without equivalent functionality in a future major release
  */
 class UserFormsGridFieldFilterHeader extends GridFieldFilterHeader
 {
@@ -31,6 +33,11 @@ class UserFormsGridFieldFilterHeader extends GridFieldFilterHeader
      * @var array
      */
     protected $columns;
+
+    public function __construct()
+    {
+        Deprecation::noticeWithNoReplacment('7.2.0', '', Deprecation::SCOPE_CLASS);
+    }
 
     public function setColumns($columns)
     {

--- a/code/Model/EditableFormField.php
+++ b/code/Model/EditableFormField.php
@@ -133,6 +133,7 @@ class EditableFormField extends DataObject
         'RightTitle' => 'Varchar(255)',
         'ShowOnLoad' => 'Boolean(1)',
         'ShowInSummary' => 'Boolean',
+        'Searchable' => 'Boolean',
         'Placeholder' => 'Varchar(255)',
         'DisplayRulesConjunction' => 'Enum("And,Or","Or")',
     ];
@@ -261,6 +262,7 @@ class EditableFormField extends DataObject
                     $this->i18n_singular_name()
                 ),
                 CheckboxField::create('ShowInSummary', _t(__CLASS__.'.SHOWINSUMMARY', 'Show in summary gridfield')),
+                CheckboxField::create('Searchable', _t(__CLASS__.'.SHOWINSEARCH', 'Show in summary search')),
                 LiteralField::create(
                     'MergeField',
                     '<div class="form-group field readonly">' .

--- a/code/Model/Filters/SubmittedFieldFilter.php
+++ b/code/Model/Filters/SubmittedFieldFilter.php
@@ -1,0 +1,61 @@
+<?php
+
+namespace SilverStripe\UserForms\Model\Filters;
+
+use SilverStripe\ORM\DataQuery;
+use SilverStripe\ORM\Filters\SearchFilter;
+use SilverStripe\UserForms\Model\Submission\SubmittedForm;
+use LogicException;
+
+class SubmittedFieldFilter extends SearchFilter
+{
+    /**
+     * @inheritDoc
+     * @throws LogicException Throws a logic exception when applied to a data class that is not a SubmittedForm
+     */
+    public function applyOne(DataQuery $query): DataQuery
+    {
+        if (!is_a($query->dataClass(), SubmittedForm::class, true)) {
+            throw new LogicException('DataQuery\'s Data Class is not an instance of ' . SubmittedForm::class);
+        }
+
+        $query->where([
+            'EXISTS (' .
+                'SELECT "ID" ' .
+                'FROM "SubmittedFormField" ' .
+                'WHERE (' .
+                    '"ParentID" = "SubmittedForm"."ID" AND ' .
+                    '"Name" = ? AND ' .
+                    '"Value" LIKE ?' .
+                ')' .
+            ')' => [$this->name, $this->value],
+        ]);
+
+        return $query;
+    }
+
+    /**
+     * @inheritDoc
+     * @throws LogicException Throws a logic exception when applied to a data class that is not a SubmittedForm
+     */
+    public function excludeOne(DataQuery $query): DataQuery
+    {
+        if (!is_a($query->dataClass(), SubmittedForm::class, true)) {
+            throw new LogicException('DataQuery\'s Data Class is not an instance of ' . SubmittedForm::class);
+        }
+
+        $query->where([
+            'NOT EXISTS (' .
+                'SELECT "ID" ' .
+                'FROM "SubmittedFormField" ' .
+                'WHERE (' .
+                    '"ParentID" = "SubmittedForm"."ID" AND ' .
+                    '"Name" = ? AND ' .
+                    '"Value" LIKE ?' .
+                ')' .
+            ')' => [$this->name, $this->value],
+        ]);
+
+        return $query;
+    }
+}

--- a/code/Model/Submission/SubmittedForm.php
+++ b/code/Model/Submission/SubmittedForm.php
@@ -43,6 +43,15 @@ class SubmittedForm extends DataObject
         'Created.Nice' => 'Created'
     ];
 
+    private static $searchable_fields = [
+        'Created' => [
+            'title' => 'Created',
+        ],
+        'SubmittedBy.Email' => [
+            'title' => 'Submitter',
+        ],
+    ];
+
     private static $table_name = 'SubmittedForm';
 
     public function requireDefaultRecords()

--- a/code/UserForm.php
+++ b/code/UserForm.php
@@ -6,6 +6,7 @@ use Colymba\BulkManager\BulkManager;
 use SilverStripe\Core\Config\Configurable;
 use SilverStripe\Forms\CheckboxField;
 use SilverStripe\Forms\CompositeField;
+use SilverStripe\Forms\DropdownField;
 use SilverStripe\Forms\FieldList;
 use SilverStripe\Forms\GridField\GridField;
 use SilverStripe\Forms\GridField\GridFieldButtonRow;
@@ -32,6 +33,7 @@ use SilverStripe\ORM\DB;
 use SilverStripe\UserForms\Extension\UserFormFieldEditorExtension;
 use SilverStripe\UserForms\Extension\UserFormValidator;
 use SilverStripe\UserForms\Model\EditableFormField;
+use SilverStripe\UserForms\Model\EditableFormField\EditableMultipleOptionField;
 use SilverStripe\UserForms\Model\Filters\SubmittedFieldFilter;
 use SilverStripe\UserForms\Model\Recipient\EmailRecipient;
 use SilverStripe\UserForms\Model\Submission\SubmittedForm;
@@ -316,7 +318,12 @@ SQL;
         if ($searchFields->exists()) {
             foreach ($searchFields as $formField) {
                 $field = $formField->getFormField();
-                if ($field instanceof SingleSelectField) {
+                $field->setValue('');
+
+                if ($formField instanceof EditableMultipleOptionField) {
+                    $field = DropdownField::create($field->getName(), $field->Title(), $field->getSource())
+                        ->setEmptyString('(' . _t('SilverStripe\\UserForms\\Model\\UserDefinedForm.ANY', 'Any') . ')');
+                } elseif ($field instanceof SingleSelectField) {
                     $field->setEmptyString('(' . _t('SilverStripe\\UserForms\\Model\\UserDefinedForm.ANY', 'Any') . ')');
                 }
 

--- a/code/UserForm.php
+++ b/code/UserForm.php
@@ -3,6 +3,7 @@
 namespace SilverStripe\UserForms;
 
 use Colymba\BulkManager\BulkManager;
+use SilverStripe\Core\Config\Configurable;
 use SilverStripe\Forms\CheckboxField;
 use SilverStripe\Forms\CompositeField;
 use SilverStripe\Forms\FieldList;
@@ -14,6 +15,7 @@ use SilverStripe\Forms\GridField\GridFieldDeleteAction;
 use SilverStripe\Forms\GridField\GridFieldDetailForm;
 use SilverStripe\Forms\GridField\GridFieldEditButton;
 use SilverStripe\Forms\GridField\GridFieldExportButton;
+use SilverStripe\Forms\GridField\GridFieldFilterHeader;
 use SilverStripe\Forms\GridField\GridFieldPageCount;
 use SilverStripe\Forms\GridField\GridFieldPaginator;
 use SilverStripe\Forms\GridField\GridFieldPrintButton;
@@ -22,18 +24,18 @@ use SilverStripe\Forms\GridField\GridFieldToolbarHeader;
 use SilverStripe\Forms\HTMLEditor\HTMLEditorField;
 use SilverStripe\Forms\LabelField;
 use SilverStripe\Forms\LiteralField;
+use SilverStripe\Forms\SingleSelectField;
 use SilverStripe\Forms\TextField;
 use SilverStripe\Forms\Validation\CompositeValidator;
 use SilverStripe\Model\List\ArrayList;
 use SilverStripe\ORM\DB;
 use SilverStripe\UserForms\Extension\UserFormFieldEditorExtension;
 use SilverStripe\UserForms\Extension\UserFormValidator;
-use SilverStripe\UserForms\Form\UserFormsGridFieldFilterHeader;
+use SilverStripe\UserForms\Model\EditableFormField;
+use SilverStripe\UserForms\Model\Filters\SubmittedFieldFilter;
 use SilverStripe\UserForms\Model\Recipient\EmailRecipient;
 use SilverStripe\UserForms\Model\Submission\SubmittedForm;
-use SilverStripe\UserForms\Model\EditableFormField;
 use SilverStripe\View\Requirements;
-use SilverStripe\Core\Config\Configurable;
 
 /**
  * Defines the user defined functionality to be applied to any {@link DataObject}
@@ -265,7 +267,8 @@ SQL;
         $config = GridFieldConfig::create();
         $config->addComponent(new GridFieldToolbarHeader());
         $config->addComponent(new GridFieldSortableHeader());
-        $config->addComponent($filter = new UserFormsGridFieldFilterHeader());
+        $config->addComponent(new GridFieldButtonRow('before'));
+        $config->addComponent($filter = new GridFieldFilterHeader());
         $config->addComponent(new GridFieldDataColumns());
         $config->addComponent(new GridFieldEditButton());
         $config->addComponent(new GridFieldDeleteAction());
@@ -292,11 +295,6 @@ SQL;
             $config->addComponent(new BulkManager);
         }
 
-        // attach every column to the print view form
-        $columns['Created'] = 'Created';
-        $columns['SubmittedBy.Email'] = 'Submitter';
-        $filter->setColumns($columns);
-
         // print configuration
         $print->setPrintHasHeader(true);
         $print->setPrintColumns($columns);
@@ -311,6 +309,23 @@ SQL;
             $this->Submissions()->sort('Created', 'DESC'),
             $config
         );
+
+        // modify the search context for the searchable fields
+        $context = $filter->getSearchContext($submissions);
+        $searchFields = $this->Fields()->filter('Searchable', true);
+        if ($searchFields->exists()) {
+            foreach ($searchFields as $formField) {
+                $field = $formField->getFormField();
+                if ($field instanceof SingleSelectField) {
+                    $field->setEmptyString('(' . _t('SilverStripe\\UserForms\\Model\\UserDefinedForm.ANY', 'Any') . ')');
+                }
+
+                $context->addField($field);
+                $context->addFilter(new SubmittedFieldFilter($formField->Name));
+            }
+        }
+
+        $filter->setSearchContext($context);
 
         $this->extend('updateSubmissionsGridField', $submissions);
 

--- a/lang/en.yml
+++ b/lang/en.yml
@@ -93,6 +93,7 @@ en:
     REQUIRED_DESCRIPTION: "Please note that conditional fields can't be required"
     RIGHTTITLE: 'Right title'
     SHOWINSUMMARY: 'Show in summary gridfield'
+    SHOWINSEARCH': 'Show in summary search'
     SINGULARNAME: 'Editable Form Field'
     TITLE: Title
     TYPE: Type
@@ -423,3 +424,4 @@ en:
     has_many_EmailRecipients: 'Email recipients'
     has_many_Fields: Fields
     has_many_Submissions: Submissions
+    ANY: Any

--- a/tests/php/Model/UserDefinedFormTest.php
+++ b/tests/php/Model/UserDefinedFormTest.php
@@ -2,6 +2,7 @@
 
 namespace SilverStripe\UserForms\Tests\Model;
 
+use SilverStripe\CMS\Controllers\CMSMain;
 use SilverStripe\Control\Controller;
 use SilverStripe\Control\Email\Email;
 use SilverStripe\Core\Convert;
@@ -11,6 +12,7 @@ use SilverStripe\Forms\FieldList;
 use SilverStripe\Forms\Form;
 use SilverStripe\Forms\GridField\GridField;
 use SilverStripe\Forms\GridField\GridFieldDataColumns;
+use SilverStripe\Forms\GridField\GridFieldFilterHeader;
 use SilverStripe\ORM\DB;
 use SilverStripe\UserForms\Extension\UserFormFieldEditorExtension;
 use SilverStripe\UserForms\Extension\UserFormValidator;
@@ -21,6 +23,7 @@ use SilverStripe\UserForms\Model\EditableFormField\EditableEmailField;
 use SilverStripe\UserForms\Model\EditableFormField\EditableFieldGroup;
 use SilverStripe\UserForms\Model\EditableFormField\EditableFieldGroupEnd;
 use SilverStripe\UserForms\Model\Recipient\EmailRecipient;
+use SilverStripe\UserForms\Model\Submission\SubmittedForm;
 use SilverStripe\UserForms\Model\UserDefinedForm;
 use SilverStripe\Versioned\Versioned;
 
@@ -31,7 +34,10 @@ class UserDefinedFormTest extends FunctionalTest
 {
     protected $usesTransactions = false;
 
-    protected static $fixture_file = '../UserFormsTest.yml';
+    protected static $fixture_file = [
+        '../UserFormsTest.yml',
+        'UserDefinedFormTest.yml',
+    ];
 
     protected static $required_extensions = [
         UserDefinedForm::class => [UserFormFieldEditorExtension::class],
@@ -557,5 +563,63 @@ class UserDefinedFormTest extends FunctionalTest
         $result = $recipient->validate();
         $this->assertTrue($result->isValid());
         $this->assertEmpty($result->getMessages());
+    }
+
+    public function testFormFieldSearch()
+    {
+        $this->logInWithPermission('ADMIN');
+
+        $form = $this->objFromFixture(UserDefinedForm::class, 'basic-form-page');
+        $form->Fields()->add($this->objFromFixture(EditableDropdown::class, 'test-dropdown'));
+        $submission1 = $this->objFromFixture(SubmittedForm::class, 'submission1');
+        $submission2 = $this->objFromFixture(SubmittedForm::class, 'submission2');
+
+        // get the submissions grid and filter header
+        $gridField = $form->getCMSFields()->dataFieldByName('Submissions')->setForm(new Form(CMSMain::singleton(), 'TestForm'));
+        $component = $gridField->getConfig()->getComponentByType(GridFieldFilterHeader::class);
+
+        // set the state to filter based on the basic_text_name field having "Test Value 1"
+        $state = $gridField->State;
+        $state->GridFieldFilterHeader = [];
+        $state->GridFieldFilterHeader->Columns = [];
+        $state->GridFieldFilterHeader->Columns->basic_text_name = 'Test Value 1';
+
+        // make sure the list contains the submission1 but not submission2
+        $this->assertListContains(
+            [
+                ['ID' => $submission1->ID],
+            ],
+            $gridField->getManipulatedList(),
+            SubmittedForm::class . '.submission1 was not found in the GridField\'s list when it should be',
+        );
+        $this->assertListNotContains(
+            [
+                ['ID' => $submission2->ID],
+            ],
+            $gridField->getManipulatedList(),
+            SubmittedForm::class . '.submission2 was found in the GridField\'s list when it should not be',
+        );
+
+        // set the state to filter based on the basic-dropdown field having "Option 2"
+        $state = $gridField->State;
+        $state->GridFieldFilterHeader = [];
+        $state->GridFieldFilterHeader->Columns = [];
+        $state->GridFieldFilterHeader->Columns->test_dropdown = 'Option 2';
+
+        // make sure the list contains the submission2 but not submission1
+        $this->assertListContains(
+            [
+                ['ID' => $submission2->ID],
+            ],
+            $gridField->getManipulatedList(),
+            SubmittedForm::class . '.submission2 was not found in the GridField\'s list when it should be',
+        );
+        $this->assertListNotContains(
+            [
+                ['ID' => $submission1->ID],
+            ],
+            $gridField->getManipulatedList(),
+            SubmittedForm::class . '.submission1 was found in the GridField\'s list when it should not be',
+        );
     }
 }

--- a/tests/php/Model/UserDefinedFormTest.yml
+++ b/tests/php/Model/UserDefinedFormTest.yml
@@ -1,0 +1,51 @@
+SilverStripe\UserForms\Model\EditableFormField\EditableOption:
+  test-option-1:
+    Name: Option1
+    Title: Option 1
+
+  test-option-2:
+    Name: Option2
+    Title: Option 2
+
+SilverStripe\UserForms\Model\EditableFormField\EditableDropdown:
+  test-dropdown:
+    Name: test_dropdown
+    Title: Test Dropdown Field
+    Options:
+      - =>SilverStripe\UserForms\Model\EditableFormField\EditableOption.test-option-1
+      - =>SilverStripe\UserForms\Model\EditableFormField\EditableOption.test-option-2
+    Searchable: true
+
+SilverStripe\UserForms\Model\Submission\SubmittedFormField:
+  value1:
+    Title: Basic Text Field
+    Name: basic_text_name
+    Value: Test Value 1
+
+  value2:
+    Title: Test Dropdown Field
+    Name: test_dropdown
+    Value: Option 1
+
+  value3:
+    Title: Basic Text Field
+    Name: basic_text_name
+    Value: Test Value 2
+
+  value4:
+    Title: Test Dropdown Field
+    Name: test_dropdown
+    Value: Option 2
+
+SilverStripe\UserForms\Model\Submission\SubmittedForm:
+  submission1:
+    Parent: =>SilverStripe\UserForms\Model\UserDefinedForm.basic-form-page
+    Values:
+      - =>SilverStripe\UserForms\Model\Submission\SubmittedFormField.value1
+      - =>SilverStripe\UserForms\Model\Submission\SubmittedFormField.value2
+
+  submission2:
+    Parent: =>SilverStripe\UserForms\Model\UserDefinedForm.basic-form-page
+    Values:
+      - =>SilverStripe\UserForms\Model\Submission\SubmittedFormField.value3
+      - =>SilverStripe\UserForms\Model\Submission\SubmittedFormField.value4

--- a/tests/php/UserFormsTest.yml
+++ b/tests/php/UserFormsTest.yml
@@ -101,6 +101,7 @@ SilverStripe\UserForms\Model\EditableFormField\EditableTextField:
   basic-text:
     Name: basic_text_name
     Title: Basic Text Field
+    Searchable: true
 
   basic-text-2:
     Name: basic_text_name


### PR DESCRIPTION
<!--
  Thanks for contributing, you're awesome! ⭐

  Please read https://docs.silverstripe.org/en/contributing/code/ if you haven't contributed to this project recently.
-->
## Description
This PR fixes the long standing issue #919 where UserFormsGridFieldFilterHeader would never show up by replacing it with a standard GridFieldFilterHeader and a new SearchFilter. UserFormsGridFieldFilterHeader has not been removed to avoid a breaking change but it is deprecated and no longer used by default. Note: Like UserFormsGridFieldFilterHeader this just uses a case insensitive match on the value not a partial match.

## Manual testing steps
1. Create a user form
2. Create a field with the "Show in summary search" checkbox set
3. Fill out and submit the form a couple times to seed some submissions
4. On the submissions tab expand the "Search options" and search by the form field created in 2

## Issues
<!--
  List all issues here that this pull request fixes/resolves.
  If there is no issue already, create a new one! You must link your pull request to at least one issue.
-->
- #919

## Pull request checklist
<!--
  PLEASE check each of these to ensure you have done everything you need to do!
  If there's something in this list you need help with, please ask so that we can assist you.
-->
- [x] The target branch is correct
    - See [picking the right version](https://docs.silverstripe.org/en/contributing/code/#picking-the-right-version)
- [x] All commits are relevant to the purpose of the PR (e.g. no debug statements, unrelated refactoring, or arbitrary linting)
    - Small amounts of additional linting are usually okay, but if it makes it hard to concentrate on the relevant changes, ask for the unrelated changes to be reverted, and submitted as a separate PR.
- [x] The commit messages follow our [commit message guidelines](https://docs.silverstripe.org/en/contributing/code/#commit-messages)
- [x] The PR follows our [contribution guidelines](https://docs.silverstripe.org/en/contributing/code/)
- [x] Code changes follow our [coding conventions](https://docs.silverstripe.org/en/contributing/coding_conventions/)
- [x] This change is covered with tests (or tests aren't necessary for this change)
- [x] Any relevant User Help/Developer documentation is updated; for impactful changes, information is added to the changelog for the intended release
- [x] CI is green
