### PR TITLE
FIX re-roll editable form field names on duplicate, add parentID to name-based search

### DIFF
--- a/code/Form/UserFormsRequiredFieldsValidator.php
+++ b/code/Form/UserFormsRequiredFieldsValidator.php
@@ -35,6 +35,12 @@ class UserFormsRequiredFieldsValidator extends RequiredFieldsValidator
         $valid = true;
         $fields = $this->form->Fields();
 
+        // Form name comes in as <classname>_<form-id>, which is about the only way to
+        // extract the parent ID. We pull off the number after the last underscore
+        // as sometimes it's a <fully_qualified_class_name>
+        preg_match('/_(\d+)$/', $this->form->FormName(), $matches);
+        $parentId = (int) ($matches[1] ?? 0);
+
         if (empty($this->required)) {
             return $valid;
         }
@@ -53,7 +59,7 @@ class UserFormsRequiredFieldsValidator extends RequiredFieldsValidator
             }
 
             // get editable form field - owns display rules for field
-            $editableFormField = $this->getEditableFormFieldByName($fieldName);
+            $editableFormField = $this->getEditableFormFieldByName($fieldName, $parentId);
 
             // Validate if the field is displayed
             $error =
@@ -73,11 +79,20 @@ class UserFormsRequiredFieldsValidator extends RequiredFieldsValidator
     /**
      * Retrieve an Editable Form field by its name.
      * @param string $name
+     * @param int $parentId
      * @return EditableFormField
      */
-    private function getEditableFormFieldByName($name)
+    private function getEditableFormFieldByName($name, $parentId)
     {
-        $field = EditableFormField::get()->filter(['Name' => $name])->first();
+        $filterFields = [
+            'Name' => $name,
+        ];
+
+        if ($parentId > 0) {
+            $filterFields['ParentID'] = $parentId;
+        }
+
+        $field = EditableFormField::get()->filter($filterFields)->first();
 
         if ($field) {
             return $field;

--- a/code/Model/EditableFormField.php
+++ b/code/Model/EditableFormField.php
@@ -450,6 +450,18 @@ class EditableFormField extends DataObject
     }
 
     /**
+     * @param bool $doWrite
+     * @param array|null $relations
+     */
+    protected function onBeforeDuplicate($doWrite, $relations)
+    {
+        parent::onBeforeDuplicate($doWrite, $relations);
+
+        // Re-generate a name for this field so that it doesn't get found during validate by accident
+        $this->Name = $this->generateName();
+    }
+
+    /**
      * Generate a new non-conflicting Name value
      *
      * @return string

--- a/code/Model/EditableFormField.php
+++ b/code/Model/EditableFormField.php
@@ -455,8 +455,6 @@ class EditableFormField extends DataObject
      */
     protected function onBeforeDuplicate($doWrite, $relations)
     {
-        parent::onBeforeDuplicate($doWrite, $relations);
-
         // Re-generate a name for this field so that it doesn't get found during validate by accident
         $this->Name = $this->generateName();
     }

--- a/tests/php/Model/EditableFormFieldTest.php
+++ b/tests/php/Model/EditableFormFieldTest.php
@@ -180,7 +180,7 @@ class EditableFormFieldTest extends FunctionalTest
     {
         $fileField1 = $this->objFromFixture(EditableFileField::class, 'file-field-without-folder');
         $fileField2 = $this->objFromFixture(EditableFileField::class, 'file-field-with-folder');
-        
+
         $this->assertFalse($fileField1->getFolderExists());
         $this->assertTrue($fileField2->getFolderExists());
     }
@@ -205,6 +205,26 @@ class EditableFormFieldTest extends FunctionalTest
         $this->assertMatchesRegularExpression('/^EditableTextField_.+/', $textfield2->Name);
         $this->assertMatchesRegularExpression('/^EditableCheckbox_.+/', $checkboxField->Name);
         $this->assertNotEquals($textfield1->Name, $textfield2->Name);
+    }
+
+    /**
+     * Verify that duplicating a field re-rolls its Name, rather than duplicating it
+     */
+    public function testDuplicateUniqueName()
+    {
+        $textField = $this->objFromFixture(EditableTextField::class, 'basic-text');
+
+        $duplicate = $textField->duplicate();
+
+        $this->assertNotEquals(
+            $textField->Name,
+            $duplicate->Name,
+            'Duplicated field should not share the same Name as the original'
+        );
+        $this->assertMatchesRegularExpression('/^EditableTextField_.+/', $duplicate->Name);
+
+        // Original field is untouched
+        $this->assertEquals('basic_text_name', $textField->Name);
     }
 
     public function testLengthRange()


### PR DESCRIPTION
## Description

Gives duplicated fields unique `Name` attributes and adds additional `ParentID` filter to name-based lookup on validate.

## Manual testing steps

Create form
Duplicate form
See that form fields, while otherwise identical, have different names

## Issues

#1446 

## Pull request checklist

- [x] The target branch is correct
    - See [picking the right version](https://docs.silverstripe.org/en/contributing/code/#picking-the-right-version)
- [x] All commits are relevant to the purpose of the PR (e.g. no debug statements, unrelated refactoring, or arbitrary linting)
    - Small amounts of additional linting are usually okay, but if it makes it hard to concentrate on the relevant changes, ask for the unrelated changes to be reverted, and submitted as a separate PR.
- [x] The commit messages follow our [commit message guidelines](https://docs.silverstripe.org/en/contributing/code/#commit-messages)
- [x] The PR follows our [contribution guidelines](https://docs.silverstripe.org/en/contributing/code/)
- [x] Code changes follow our [coding conventions](https://docs.silverstripe.org/en/contributing/coding_conventions/)
- [x] This change is covered with tests (or tests aren't necessary for this change)
- [x] Any relevant User Help/Developer documentation is updated; for impactful changes, information is added to the changelog for the intended release
- [x] CI is green
